### PR TITLE
Fix Bug: If you select 'Do not Translate', the Extension stop working

### DIFF
--- a/Source/options.js
+++ b/Source/options.js
@@ -187,7 +187,7 @@ function restorePatterns(data){
       <input type='hidden' value='-1' \
       </p>");
   nonElem.click(function() {
-      activatePattern(-1, data);
+      activatePattern(-1, patterns);
   });
   patternsElem.append(nonElem);
   console.log("restorePatterns end");


### PR DESCRIPTION
Fixing issue reported by multiple users, here is one user description:-

Donald Rice II Modified Apr 6, 2015
If you select " Do not Translate," the Extension will forever not work, and you can not create another option to make it work (I was having problems changing things to Japanese until I tried doing that without hitting " do not translate."
Please fix this bug!