### PR TITLE
Adding option to pick yandex as a translation service.

### DIFF
--- a/Source/options.html
+++ b/Source/options.html
@@ -249,13 +249,33 @@
               </p>
             </div>
           </div>
-          <div class="row-fluid">
+
+        <div class="span12 optionsSpan">
+            <hr>
+            <h3>Translation</h3>
+            <div class="span4 optionsSpan">
+              <p>
+                Text translation service to use: 
+              </p>
+            </div>
+            <div class="span4 optionsSpan">
+                <select id="translatorService">
+                  <option>Google Translate</option>
+                  <option>Yandex</option>
+                </select>
+            </div>
+            <div class="span4 optionsSpan">
+              <p>
+                <b id="translatorInfo"></b>
+              </p>
+            </div>
+        </div>
+
+        <div class="row-fluid">
             <hr>
             <div id="status" class="span6 offset3"> </div>
           </div>
         </div>
-
-
 
         <!-- Contributions -->
         <div class="row-fluid tab-pane" id="tContributions">

--- a/Source/options.js
+++ b/Source/options.js
@@ -17,6 +17,7 @@ var defaultStorage = {
       ngramMin: 1,
       ngramMax: 1,
       userDefinedTranslations: '{"the":"the", "a":"a"}',
+      translatorService: "Google Translate"
     }
 
 function e(id) {
@@ -42,6 +43,7 @@ function setupListeners() {
     e("blacklist").addEventListener("blur", save_blacklist);
     e("userDefinedTranslations").addEventListener("blur", save_userDefinedTranslations);
     e("userBlacklistedWords").addEventListener("blur", save_userBlacklistedWords);
+    e("translatorService").addEventListener("blur", save_translatorService);
 }
 
 function initUi() {
@@ -71,6 +73,7 @@ function updateUi(data) {
     restoreOptions(data);
     restorePatterns(data);
     showCSSExample();
+    showTranslatorLink();
     console.log("updateUI end");
 }
 
@@ -115,10 +118,22 @@ function showCSSExample(){
     e("resultSpan").innerText = synonyms[num];
 }
 
+function showTranslatorLink(){
+   var elem = e("translatorService");
+   var link = document.createElement("a");
 
-
-
-
+   if(elem.children[elem.selectedIndex].value === "Google Translate"){
+    link.href = "http://translate.google.com/";
+    link.innerText = "Powered by Google.Translate";
+   }
+   else{
+    link.href = "http://translate.yandex.com/";
+    link.innerText = "Powered by Yandex.Translate";
+   }
+   link.target = "_blank";
+   e("translatorInfo").innerHTML = '';
+   e("translatorInfo").appendChild(link);
+}
 
 function createPattern(){
   console.log("createPattern begin");
@@ -239,7 +254,7 @@ function restoreOptions(data) {
     var options = ["sourceLanguage", "targetLanguage", "translationProbability", 
     "minimumSourceWordLength", "ngramMin", "ngramMax", 
     "translatedWordStyle", "blacklist",
-    "userDefinedTranslations", "userBlacklistedWords"];
+    "userDefinedTranslations", "userBlacklistedWords", "translatorService"];
 
     for (index in options) {
       restore(options[index], data);
@@ -352,6 +367,11 @@ function save_blacklist() {
 function save_userBlacklistedWords() {
     // ToDo: Implement validation
     save("userBlacklistedWords", "Blacklisted words saved");
+}
+
+function save_translatorService() {
+   save("translatorService", "TranslatorService saved");
+   showTranslatorLink();
 }
 
 function save_ngramMin() {


### PR DESCRIPTION
Haven't tested the changes for all languages only tested it for french.
Some issue remaining:-
The set of languages supported by different services is different so need some way to validated the languages that can be added for translation.
Need to have a map for language to its short form like french to fr, since for some languages it is different for google translate and yandex.

Since google translate is currently not working because it is blocking calls I guess this will be good workaround for some users like me atleast.