### PR TITLE
fixed options pages

### DIFF
--- a/Source/options.js
+++ b/Source/options.js
@@ -199,8 +199,11 @@ $(function() {
 
   function createPattern() {
     console.log('createPattern begin');
-    var patterns = JSON.parse(S('savedPatterns')),
-      src = [],
+    var patterns = [];
+    if (S('savedPatterns') !== undefined) {
+      patterns = JSON.parse(S('savedPatterns'));
+    }
+    var src = [],
       trg = [],
       prb = [];
 


### PR DESCRIPTION
In function `createPattern`, the variable `pattern` was accessing undefined `savedPatterns` from the local storage. This is fixed by adding a simple check.