### PR TITLE
Issue with user defined translations

### DIFF
--- a/Source/MindTheWord.js
+++ b/Source/MindTheWord.js
@@ -92,18 +92,21 @@ function containsIllegalCharacters(s) {
 }
 
 function processTranslations(translationMap, userDefinedTMap) {
+
   var filteredTMap = {};
   for (var w in translationMap) {
     if (w != translationMap[w] && translationMap[w] !== '' && !userDefinedTMap[w] && !containsIllegalCharacters(translationMap[w])) {
       filteredTMap[w] = translationMap[w];
     }
   }
+
   for (w in userDefinedTMap) {
     if (w != userDefinedTMap[w]) {
       filteredTMap[w] = userDefinedTMap[w];
     }
   }
-  if (length(filteredTMap) !== 0) {
+
+  if (length(filteredTMap) != 0) {
     paragraphs = document.getElementsByTagName('p');
     for (var i = 0; i < paragraphs.length; i++) {
       deepHTMLReplacement(paragraphs[i], filteredTMap, invertMap(filteredTMap));

--- a/Source/options.js
+++ b/Source/options.js
@@ -392,8 +392,12 @@ $(function() {
     var v;
     if (elem.tagName.toLowerCase() == 'select') {
       v = elem.children[elem.selectedIndex].value;
-    } else {
-      v = elem.value;
+    } 
+    else if (elem.type.toLowerCase() == 'checkbox'){
+      v = elem.checked
+    }
+    else {
+      v = elem.value
     }
     console.log('Saving ' + id + ' as ' + v);
     if (cachedStorage[id] != v) {

--- a/Source/popup.html
+++ b/Source/popup.html
@@ -3,7 +3,7 @@
   <head>
     <title>Mind The Word</title>
     <link href="assets/css/bootstrap.css" rel="stylesheet">
-    <script type="text/javascript" src="assets/js/angular.min.js"></script> //angularjs lib
+    <script type="text/javascript" src="assets/js/angular.min.js"></script>
     <script type="text/javascript" src="popup.js"></script>
   </head>
   <body>


### PR DESCRIPTION
**In reference to #62**

I think this was the reason why some people thought that the extension wasn't working. In the file **options.js** there is a function **save**. Earlier there was no separate check for a checkbox in the function due to which **v was defaulting to a string on**. 
<img width="399" alt="screen shot 2016-03-07 at 11 35 00 am" src="https://cloud.githubusercontent.com/assets/2452426/13562062/e35469f2-e459-11e5-839e-b68b4ce4ea72.png">

The default string value caused the **main** function in MindTheWord.js to always default to the option with **limitToUserDefined**
<img width="838" alt="screen shot 2016-03-07 at 11 39 32 am" src="https://cloud.githubusercontent.com/assets/2452426/13561999/49d42baa-e459-11e5-87ca-92a476d8f41d.png">

But the default value for **limitToUserDefined**  is set to **{"the":"the", "a":"a"}**. There is a check in the **function processTranslations** which filters such translations. 

<img width="649" alt="screen shot 2016-03-07 at 11 42 02 am" src="https://cloud.githubusercontent.com/assets/2452426/13562037/a26272ae-e459-11e5-98f3-4635db017894.png">

The check I have added ensures that the current value of the limit to user defined translations checkbox gets through. After making this edit the extension is working perfectly fine for me