### PR TITLE
fix duplicate pattern input in createPattern function

### DIFF
--- a/Source/options.js
+++ b/Source/options.js
@@ -203,12 +203,24 @@ $(function() {
     prb[0] = document.getElementById('translationProbability');
     prb[1] = prb[0].children[prb[0].selectedIndex].value;
 
-    patterns.push([[src[1], src[2]],
+    var duplicateInput = false; //to check duplicate patterns
+    for (index in patterns) {
+      if (patterns[index][0][0] === src[1] && patterns[index][1][0] === trg[1] && patterns[index][2] === prb[1]) {
+        duplicateInput = true;
+        status('Pattern already exists', 9000, 600, 'error');
+      }
+    }
+
+    if (duplicateInput === false) {
+      patterns.push([
+        [src[1], src[2]],
         [trg[1], trg[2]],
         prb[1],
         false,
         service
-    ]);
+      ]);
+    }
+
     saveBulk({'savedPatterns': JSON.stringify(patterns)}, 'Saved Pattern');
     console.log('createPattern end');
   }


### PR DESCRIPTION
When a user creates the same pattern again, this fix raises a warning and does not allow duplicate creation.

> This is good. Avoiding creating repeated translation patterns is good. Remember to warn the user that a new pattern has not been created because it already exists.

I have put the warning.

>This is not good. It is ok to have two patterns with the same languages and different probabilities. For instance, if I am learning Russian, I could be interested in having two translation patterns from English to Russian: one with low probability, for everyday use; and one with high probability, when I really want to study Russian harder.

I have made the changes suggested. Now same languages with different probabilities can be created.

This change was initially in pull request #65. 