### PR TITLE
default translator set to Yandex

### DIFF
--- a/Source/background.js
+++ b/Source/background.js
@@ -9,11 +9,11 @@ var defaultStorage = {
   savedPatterns: JSON.stringify([
     [
       ['en', 'English'],
-      ['it', 'Italian'], '25', true
+      ['it', 'Italian'], '25', true, 'Yandex'
     ],
     [
       ['en', 'English'],
-      ['la', 'Latin'], '15', false
+      ['de', 'German'], '15', false, 'Yandex'
     ]
   ]),
   sourceLanguage: 'en',
@@ -25,7 +25,7 @@ var defaultStorage = {
   ngramMin: 1,
   ngramMax: 1,
   userDefinedTranslations: '{"the":"the", "a":"a"}',
-  translatorService: 'Google Translate',
+  translatorService: 'Yandex',
   yandexTranslatorApiKey: ''
 };
 

--- a/Source/options.html
+++ b/Source/options.html
@@ -82,7 +82,7 @@
                     </p>
 
                     <p>
-                    <b>Attention:</b> Google Translate is currently <i>unreliable</i>. Yandex is <i>recommended</i>!
+                    <b>Attention:</b> Google Translate is <i>not free</i>. Yandex is <i>recommended</i>!
                     </p>
                 </div>
                 <div>

--- a/Source/options.js
+++ b/Source/options.js
@@ -9,11 +9,11 @@ var defaultStorage = {
   savedPatterns: JSON.stringify([
     [
       ['en', 'English'],
-      ['it', 'Italian'], '25', true
+      ['it', 'Italian'], '25', true, 'Yandex'
     ],
     [
       ['en', 'English'],
-      ['la', 'Latin'], '15', false
+      ['de', 'German'], '15', false, 'Yandex'
     ]
   ]),
   sourceLanguage: 'en',
@@ -26,7 +26,7 @@ var defaultStorage = {
   ngramMax: 1,
   userDefinedTranslations: '{"the":"the", "a":"a"}',
   limitToUserDefined: false,
-  translatorService: 'Google Translate',
+  translatorService: 'Yandex',
   yandexTranslatorApiKey: ''
 };
 
@@ -264,7 +264,7 @@ $(function() {
       patterns = defaultStorage;
     }
 
-    console.log('savedPatterns: ' + patterns);
+    console.log('savedPatterns', patterns);
     var patternsElem = $('#savedTranslationPatterns').html('');
 
     // DeleteButton should only be shown if there are two or more patterns
@@ -339,7 +339,7 @@ $(function() {
       toSave.sourceLanguage = selectedPattern[0][0];
       toSave.targetLanguage = selectedPattern[1][0];
       toSave.translationProbability = selectedPattern[2];
-      toSave.translatorService = selectedPattern[4] || 'Google Translate';
+      toSave.translatorService = selectedPattern[4] || 'Yandex';
 
       if (toSave.translatorService === 'Yandex') {
         message += ' Make sure you have setup Yandex Api key';


### PR DESCRIPTION
Default translator set to Yandex as discussed in #81 

Yandex does not support translation to Latin, so it has been changed to German in the default case.