### PR TITLE
Saving words to user dictionary. UPD

### DIFF
--- a/Source/options.js
+++ b/Source/options.js
@@ -570,6 +570,30 @@ $(function() {
           }
         }
       });
+    } else if(request.updateUserDictionary) {
+        chrome.storage.local.get('userDefinedTranslations', function(result) {
+          userDictionary = result.userDefinedTranslations;
+          userDict = JSON.parse(userDictionary);
+          console.log(userDict);
+
+          wordToSave = request.word;
+          translationToSave = request.translation;
+          //to avoid duplication
+          if (!userDict[wordToSave]) {
+            
+            userDict[wordToSave] = translationToSave;
+
+            stingifiedDict = JSON.stringify(userDict);
+            
+            id = 'userDefinedTranslations';
+            if (cachedStorage[id] !== stingifiedDict) {
+              console.log('saving');
+              var map = {};
+              map[id] = stingifiedDict;
+              saveBulk(map, 'userDefinedTranslations saved');
+            }
+          }
+        });
     }
   });
 


### PR DESCRIPTION
Update #84.
User can save translated words to the dictionary using context menu:
![mtw1](https://cloud.githubusercontent.com/assets/9070343/13697769/5df60b22-e778-11e5-8f26-8e50885c13f5.png)

![mtw2](https://cloud.githubusercontent.com/assets/9070343/13697801/97623408-e778-11e5-983f-897790da80d2.png)

