### PR TITLE
Unit testing and Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: node_js
+node_js:
+  - stable
+
+before_script:
+  - npm install -g jspm karma-cli
+
+install:
+  - npm install
+  - jspm install
+
+script:
+  - npm test
+
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - node_modules
+    - jspm_packages

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -6,12 +6,12 @@ This package uses `jspm` to manage modules for javascript.
 To have a development copy of the code, clone the repository. Run the following commands in your cloned directory.
 
 ```shell
-npm install -g jspm gulp gulp-cli jsdoc
+npm install -g jspm gulp gulp-cli jsdoc karma-cli
 npm install
 jspm install
 ```
 
-Install the extension in Chrome as an unpacked extension. Install the folder which has `manifest.json` 
+Install the extension in Chrome as an unpacked extension. Install the folder which has `manifest.json`
 
 **To start the chrome application**, run
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,115 @@
+// Karma configuration
+// Reference: https://www.youtube.com/watch?v=3D7o9BQHY7Q
+
+module.exports = function(config) {
+  config.set({
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+    // karma-babel-preprocessor settings
+    // tell it to use babel-preset-es2015
+    babelPreprocessor: {
+      options: {
+        presets: ['es2015'],
+        sourceMap: 'inline'
+      }
+    },
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: [
+      'PhantomJS'
+    ],
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
+
+    // list of files to exclude
+    exclude: [],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'lib/assets/**/*.js'
+    ],
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: [
+      'jspm',
+      'jasmine',
+      'sinon-chrome'
+    ],
+
+    jspm: {
+      config: 'config.js',
+      packages: 'jspm_packages/',
+      loadFiles: [
+        'test/**/*.js'
+      ],
+      serveFiles: [
+        'lib/scripts/**/*.js'
+      ]
+    },
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    plugins: [
+      'karma-babel-preprocessor',
+      'karma-jasmine',
+      'karma-jspm',
+      'karma-phantomjs-launcher',
+      'karma-spec-reporter',
+      'karma-sinon-chrome',
+      'karma-chrome-launcher'
+    ],
+
+    // web server port
+    port: 9000,
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'lib/scripts/**/*.js': ['babel'],
+      'test/**/*.js': ['babel']
+    },
+
+    // set up proxies so the test server will be able to find our files
+    proxies: {
+      '/lib/': '/base/lib/',
+      '/jspm_packages/': '/base/jspm_packages/',
+      '/test/': '/base/test/',
+      '/services/': '/base/lib/scripts/services/',
+      '/utils/' : '/base/lib/scripts/utils/'
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: [
+      'spec'
+    ],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // set up the spec reporter - I just want to see the "expected x to equal y" output in errors
+    specReporter: {
+      maxLogLines: 1,
+      suppressErrorSummary: true,
+      suppressFailed: false,
+      suppressPassed: false,
+      suppressSkipped: false
+    }
+  });
+};

--- a/lib/scripts/controllers/options.js
+++ b/lib/scripts/controllers/options.js
@@ -4,7 +4,7 @@ import bootstrap from 'bootstrap';
 import bootstrapcolorpicker from '../../assets/js/bootstrap-colorpicker.min.js'
 
 /** Class for option page angular controller */
-class OptionCtrl {
+export class OptionCtrl {
   /**
    * Initialize options page data and jQuery
    * @constructor

--- a/lib/scripts/controllers/popup.js
+++ b/lib/scripts/controllers/popup.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import bootstrap from 'bootstrap';
 
 /** Class for popup angular controller */
-class PopupCtrl {
+export class PopupCtrl {
   /**
    * Initialize activation data.
    * @constructor

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -265,7 +265,7 @@ export class ContentScript {
 var MTWTranslator = new ContentScript();
 MTWTranslator.translate();
 
-chrome.extension.onMessage.addListener(function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if(request.type === 'toggleAllElements'){
     MTWTranslator.toggleAllElements();
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "MindTheWord",
   "description": "Mind the Word Chrome Extension",
   "version": "2.0.3",
+  "repository": "https://github.com/OiWorld/MindTheWord",
+  "license": "",
+  "scripts": {
+    "test": "karma start"
+  },
   "jspm": {
     "dependencies": {
       "angular": "github:angular/bower-angular@^1.5.5",
@@ -19,10 +24,21 @@
     }
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.9.0",
     "del": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-jspm": "^0.5.10",
     "gulp-rename": "^1.2.2",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.22",
+    "karma-babel-preprocessor": "^6.0.1",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-jspm": "^2.1.1",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sinon-chrome": "^0.2.0",
+    "karma-spec-reporter": "0.0.26",
+    "phantomjs-prebuilt": "^2.1.7",
     "run-sequence": "^1.1.5"
   }
 }

--- a/test/specs/background.js
+++ b/test/specs/background.js
@@ -1,0 +1,51 @@
+import '/lib/scripts/eventPage'
+
+/**
+ * All chrome function calls should be mocked here.
+ * To spy on chrome API calls, you need to mock them
+ * out to global scope.
+ * All these functions are spied by Jasmine to test
+ * various functionalities
+ */
+global.chrome =  {
+  storage: {
+    local: {
+      get: jasmine.createSpy('get'),
+      set: jasmine.createSpy('set')
+    }
+  },
+  contextMenus: {
+    onClicked: {
+      addListener: jasmine.createSpy('addListener')
+    }
+  },
+  runtime: {
+    onMessage: {
+      addListener: jasmine.createSpy('addListener')
+    },
+    onInstalled: {
+      addListener: jasmine.createSpy('addListener')
+    }
+  }
+}
+
+describe('event page (background page) testing', () => {
+
+  var chrome;
+
+  beforeEach(() => {
+    chrome = global.chrome;
+  });
+
+  it('should add context menu click listeners', () => {
+    expect(chrome.runtime.onMessage.addListener).toHaveBeenCalled();
+  });
+
+  it('should check on Install condition', () => {
+    // find a way to test
+  });
+
+  it('should setup default data', () => {
+    // find a way to test
+  });
+});

--- a/test/specs/contentScript.js
+++ b/test/specs/contentScript.js
@@ -1,0 +1,16 @@
+import { ContentScript } from 'lib/scripts/mtw'
+
+describe('content script testing', function() {
+  var chrome,
+    contentScript;
+
+  beforeEach(function(){
+    chrome = global.chrome;
+    contentScript = new ContentScript();
+  })
+
+  it('should return true for illegal characters', () => {
+    expect(contentScript.containsIllegalCharacters('123')).toBe(true);
+  });
+
+});

--- a/test/specs/options.js
+++ b/test/specs/options.js
@@ -1,10 +1,59 @@
-var options = require('../../lib/scripts/controllers/options');
-var expect = require('chai').expect;
+import { OptionCtrl } from '/lib/scripts/controllers/options'
 
-describe('options page specs', function(){
-  describe('pattern functions test cases', function(){
-    it('should be true', function(){
-      expect(true).to.be.true;
+describe('options page testing', () => {
+  var ctrl,
+    scope,
+    chrome;
+
+  beforeEach(() => {
+    ctrl = new OptionCtrl(scope);
+    chrome = global.chrome;
+  });
+
+  describe('helper function tests', () => {
+    it('should set data to default', () => {
+      expect(ctrl.percentage).toEqual('15')
+      expect(ctrl.translator).toEqual('Yandex')
+      // check more
+    });
+
+    it('should call chrome.storage.local.set storage on save', () => {
+      ctrl.save({data: 'check'}, 'message');
+      expect(chrome.storage.local.set).toHaveBeenCalled();
+    });
+  })
+
+  describe('pattern functions tests', ()  => {
+
+    it('should call save on createPattern', () => {
+
+    });
+
+    it('should activate the selected pattern', () => {
+
+    });
+
+    it('should delete the selected pattern', () => {
+
+    });
+
+    it('should switch the key according to the translator', () => {
+
+    });
+
+    it('should update API key', () => {
+
+    });
+
+  })
+
+  describe('blacklist functions tests', () => {
+    it('should add a word to the blacklist', () => {
+
+    });
+
+    it('should add a website to the blacklist', () => {
+
     });
   });
 });

--- a/test/specs/popup.js
+++ b/test/specs/popup.js
@@ -1,0 +1,29 @@
+import { PopupCtrl } from '/lib/scripts/controllers/popup'
+
+describe('popup page testing', () => {
+  var ctrl,
+    scope,
+    chrome;
+
+  beforeEach(() => {
+    ctrl = new PopupCtrl(scope);
+    chrome = global.chrome;
+  });
+
+  it('should get data on creation', () => {
+    expect(chrome.storage.local.get).toHaveBeenCalled();
+  });
+
+  it('should set activation data', () => {
+
+  });
+
+  it('should open options page', () => {
+
+  });
+
+  it('should call options page toggle', () => {
+
+  });
+
+});


### PR DESCRIPTION
Unit Testing
----------

Include unit testing using `jasmine` and `karma`. It tests all the files independently and verifies its functionality. 

To run the tests
```shell
npm i -g gulp-cli
npm install
npm test
```

You should see a screen like this:
![tests](https://cloud.githubusercontent.com/assets/9019878/15514212/a5cfedba-2205-11e6-90df-722215eed5a5.png)

Right now many of the tests are empty. Over time, we will fill the test cases.

Travis CI
--------------
This PR also completes the `travis.yml` file required for checks to pass. I expect it to work as I cannot test without pushing rights to the repo. If this script works, all the PRs will be tested for these tests and if any of the tests fail, it will show a cross.

**Note:** Travis CI needs to be tested. 
