### PR TITLE
Difficulty buckets in context menu

### DIFF
--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -5,6 +5,8 @@ console.log('eventPage running');
 
  var contextMenuFeatures = new ContextMenu();
 
+ var translatedWords;
+
 //sets up default data in localStorage
 function setupDefaultData() {
   console.log('Initializing Local Storage');
@@ -154,64 +156,71 @@ chrome.runtime.onInstalled.addListener(function() {
   });
 });
 
+function getCurrentTabURL(){
+  var promise = new Promise(function(resolve, reject){
+    chrome.tabs.query({currentWindow: true, active: true}, function(tabs){
+        resolve(tabs[0].url);
+    });
+  })
+}
+
 // context menu handlers
 chrome.contextMenus.onClicked.addListener(onClickHandler);
 function onClickHandler(info, tab) {
-  if (info.menuItemId == "blacklistWebsite") {
-    var addUrlToBlacklist = contextMenuFeatures.addUrlToBlacklist;
-    chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
-      addUrlToBlacklist(tabs[0].url);
-    });
-
-  } else if (info.menuItemId == "blacklistWord") {
-    contextMenuFeatures.addWordToBlacklist(info.selectionText);
-    //TODO: move saveWord to a class function
-  } else if (info.menuItemId === "saveWord") {
-      selectedText = info.selectionText;
-      var translation = currentTranslatedMap[selectedText];
-      if (currentTranslatedMap[selectedText]) {
-        console.log('To save:' + selectedText);
-        chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
-      }
-      else {
-        alert('Please select translated word. "' + selectedText + '" is not translated.'  );
-      }
-  }
-  // Sub options under search for similar words
-  else if (info.menuItemId === "searchForSimilarWordsOnThesaurus"){
-    contextMenuFeatures.searchForSimilarWords(info.selectionText, 'thesaurus');
-  }
-  else if (info.menuItemId === "searchForSimilarWordsOnGoogle"){
-    contextMenuFeatures.searchForSimilarWords(info.selectionText, 'google');
-  }
-  else if (info.menuItemId === "searchForSimilarWordsOnBing"){
-    contextMenuFeatures.searchForSimilarWords(info.selectionText, 'bing');
-  }
-  else if (info.menuItemId === "searchForSimilarWordsOnGoogleImages"){
-    contextMenuFeatures.searchForSimilarWords(info.selectionText, 'googleImages');
-  }
-  // Sub options under Selected Word Usage Examples
-  else if (info.menuItemId === "wordUsageExamplesYourDictionary"){
-    contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'yourdictionary.com');
-  }
-  else if (info.menuItemId === "wordUsageExamplesUseInASentence"){
-    contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'use-in-a-sentence.com');
-  }
-  else if (info.menuItemId === "wordUsageExamplesManyThings"){
-    contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'manythings.org');
-  }
-  else if (info.menuItemId === "speakTheWord"){
-    contextMenuFeatures.speakTheWord(info.selectionText);
-  }
-  else if (info.menuItemId === "addToDifficultyBucketEasy"){
-    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'e');
-  }
-  else if (info.menuItemId === "addToDifficultyBucketNormal"){
-    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'n');
-  }
-  else if (info.menuItemId === "addToDifficultyBucketHard"){
-    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'h');
-  }
+  chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
+    var tabURL = tabs[0].url;
+    if (info.menuItemId == "blacklistWebsite") {
+      contextMenuFeatures.addUrlToBlacklist(tabURL);
+    } else if (info.menuItemId == "blacklistWord") {
+      contextMenuFeatures.addWordToBlacklist(info.selectionText, tabURL);
+    } else if (info.menuItemId === "saveWord") {
+        // selectedText = info.selectionText;
+        // var translation = currentTranslatedMap[selectedText];
+        // if (currentTranslatedMap[selectedText]) {
+        //   console.log('To save:' + selectedText);
+        //   chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
+        // }
+        // else {
+        //   alert('Please select translated word. "' + selectedText + '" is not translated.'  );
+        // }
+    }
+    else if (info.menuItemId === "searchForSimilarWordsOnThesaurus"){
+      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'thesaurus', tabURL);
+    }
+    else if (info.menuItemId === "searchForSimilarWordsOnGoogle"){
+      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'google', tabURL);
+    }
+    else if (info.menuItemId === "searchForSimilarWordsOnBing"){
+      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'bing', tabURL);
+    }
+    else if (info.menuItemId === "searchForSimilarWordsOnGoogleImages"){
+      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'googleImages', tabURL);
+    }
+    else if (info.menuItemId === "speakTheWord"){
+      contextMenuFeatures.speakTheWord(info.selectionText, tabURL);
+    }
+    else if (info.menuItemId === "addToDifficultyBucketEasy"){
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
+          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
+        });
+      });
+    }
+    else if (info.menuItemId === "addToDifficultyBucketNormal"){
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
+          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
+        });
+      });
+    }
+    else if (info.menuItemId === "addToDifficultyBucketHard"){
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
+          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
+        });
+      });
+    }
+  });
 }
 
 // google_analytics('UA-1471148-13');

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -35,7 +35,10 @@ function setupDefaultData() {
     yandexTranslatorApiKey: '',
     googleTranslatorApiKey: '',
     bingTranslatorApiKey: '',
-    playbackOptions: '{"volume": 1.0, "rate": 1.0, "voiceName": "Google US English", "pitch": 0.5 }'
+    playbackOptions: '{"volume": 1.0, "rate": 1.0, "voiceName": "Google US English", "pitch": 0.5 }',
+    // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
+    // E -> easy, N -> normal, H -> hard
+    difficultyBuckets: '{}'
   };
   chrome.storage.local.set(localData);
 }
@@ -125,6 +128,30 @@ chrome.runtime.onInstalled.addListener(function() {
     'contexts': ['selection'],
     'id': 'wordUsageExamplesManyThings'
   });
+  chrome.contextMenus.create({
+    'title': 'Add To Difficulty Bucket',
+    'parentId': 'parent',
+    'contexts': ['selection'],
+    'id': 'addToDifficultyBucket'
+  });
+  chrome.contextMenus.create({
+    'title': 'Easy',
+    'parentId': 'addToDifficultyBucket',
+    'contexts': ['selection'],
+    'id': 'addToDifficultyBucketEasy'
+  });
+  chrome.contextMenus.create({
+    'title': 'Normal',
+    'parentId': 'addToDifficultyBucket',
+    'contexts': ['selection'],
+    'id': 'addToDifficultyBucketNormal'
+  });
+  chrome.contextMenus.create({
+    'title': 'Hard',
+    'parentId': 'addToDifficultyBucket',
+    'contexts': ['selection'],
+    'id': 'addToDifficultyBucketHard'
+  });
 });
 
 // context menu handlers
@@ -175,6 +202,15 @@ function onClickHandler(info, tab) {
   }
   else if (info.menuItemId === "speakTheWord"){
     contextMenuFeatures.speakTheWord(info.selectionText);
+  }
+  else if (info.menuItemId === "addToDifficultyBucketEasy"){
+    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'e');
+  }
+  else if (info.menuItemId === "addToDifficultyBucketNormal"){
+    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'n');
+  }
+  else if (info.menuItemId === "addToDifficultyBucketHard"){
+    contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'h');
   }
 }
 

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -2,6 +2,9 @@ import { YandexTranslate } from './services/yandexTranslate'
 import { BingTranslate } from './services/bingTranslate'
 import { GoogleTranslate } from './services/googleTranslate'
 
+
+var tMapForMessageResponse;
+
 export class ContentScript {
   constructor() {
     this.srcLang = '';
@@ -26,6 +29,7 @@ export class ContentScript {
         this.bingTranslatorApiKey = res.bingTranslatorApiKey;
         this.googleTranslatorApiKey = res.googleTranslatorApiKey;
         this.translated = true;
+        this.difficultyBuckets = res.difficultyBuckets;
         var blacklistWebsiteReg = new RegExp(res.blacklist);
 
         if (blacklistWebsiteReg.test(document.URL)) {
@@ -77,6 +81,13 @@ export class ContentScript {
   injectCSS(cssStyle) {
     try {
       document.styleSheets[0].insertRule('span.mtwTranslatedWord {' + cssStyle + '}', 0);
+
+      // For words belong to difficulty buckets
+      // difficultyLevels: e -> easy, n -> normal, h -> hard
+      // class name mtwTranslatedWord + difficultyLevel
+      document.styleSheets[0].insertRule('span.mtwTranslatedWorde {' + 'font-style: inherit;\ncolor: rgba(75, 174, 79, 1.00);\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
+      document.styleSheets[0].insertRule('span.mtwTranslatedWordn {' + 'font-style: inherit;\ncolor: rgba(164, 59, 64, 1.00);\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
+      document.styleSheets[0].insertRule('span.mtwTranslatedWordh {' + 'font-style: inherit;\ncolor: rgba(243, 66, 53, 1.00);\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
     } catch (e) {
       console.debug(e);
     }
@@ -149,6 +160,9 @@ export class ContentScript {
       }
     }
 
+    //for difficulty buckets feature 
+    tMapForMessageResponse = filteredTMap;
+
     if (Object.keys(filteredTMap).length !== 0) {
       var paragraphs = document.getElementsByTagName('p');
       for (var i = 0; i < paragraphs.length; i++) {
@@ -196,6 +210,7 @@ export class ContentScript {
   }
 
   invertMap(map) {
+    var parsedDifficultyBuckets = JSON.parse(this.difficultyBuckets);
     var iMap = {};
     var swapJs = 'toggleElement(this)';
     for (var e in map) {
@@ -203,8 +218,15 @@ export class ContentScript {
                         '" data-tl="' + this.targetLanguage +
                         '" data-query="' + e +
                         '" data-original="' + e +
-                        '" data-translated="' + map[e] +
-                        '" class="mtwTranslatedWord" onClick="' + swapJs +
+                        '" data-translated="' + map[e];
+      if(this.targetLanguage in parsedDifficultyBuckets && map[e] in parsedDifficultyBuckets[this.targetLanguage]){
+        let wordDifficultyLevel = parsedDifficultyBuckets[this.targetLanguage][map[e]];
+        iMap[map[e]] = iMap[map[e]] + '" class="mtwTranslatedWord' + wordDifficultyLevel + '"';
+      }
+      else {
+        iMap[map[e]] = iMap[map[e]] + '" class="mtwTranslatedWord"';
+      }
+      iMap[map[e]] = iMap[map[e]] + 'onClick="' + swapJs +
                         '">' + map[e] +
                         '</span>';
     }
@@ -299,5 +321,8 @@ MTWTranslator.translate();
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if(request.type === 'toggleAllElements'){
     MTWTranslator.toggleAllElements();
+  }
+  else if(request.type === 'getTranslatedWords'){
+    sendResponse({translatedWords: tMapForMessageResponse});
   }
 });

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -1,8 +1,41 @@
+function checkIfWordCountNotOne(inputString){
+    var s = inputString;
+    s = s.replace(/(^\s*)|(\s*$)/gi,"");
+    s = s.replace(/[ ]{2,}/gi," ");
+    s = s.replace(/\n /,"\n");
+    if (s.split(' ').length != 1){
+        alert('Please select a single word only. Phrases such as: "' + inputString + '" aren\'t allowed');
+        return true;
+    }
+    return false;
+}
+
+function currentURLIsBlacklistedOrMTWIsOff() {
+    var blacklistWebsiteReg, activation;
+    chrome.storage.local.get(['activation', 'blacklist'], function(result) {
+      blacklistWebsiteReg = new RegExp(result.blacklist);
+      activation = result.activation;
+    });
+
+    if (!activation){
+      alert('MindTheWord is switched off');
+      return true;
+    }
+    else if (blacklistWebsiteReg.test(document.URL)){
+      alert('Current website is blacklisted');
+      return true;
+    }
+    else{
+      return false;
+    }
+}
+
 export class ContextMenu {
 
   constructor(){}
 
   searchForSimilarWords(selectedText, searchPlatform ) {
+  if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
     var searchPlatformURLS = {
       'bing': 'http://www.bing.com/search?q=%s+synonyms&go=&qs=n&sk=&sc=8-9&form=QBLH',
       'google': 'http://www.google.com/#q=%s+synonyms&fp=1',
@@ -15,6 +48,7 @@ export class ContextMenu {
     chrome.tabs.create({
        "url":searchUrl
     });
+
   }
 
   searchForWordUsageExamples(selectedText, searchPlatform ) {
@@ -32,6 +66,8 @@ export class ContextMenu {
   }
 
   addUrlToBlacklist(tabURL){
+    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
+
     var updatedBlacklist;
     chrome.storage.local.get('blacklist', function(result) {
       var currentBlacklist = result.blacklist;
@@ -55,10 +91,13 @@ export class ContextMenu {
   }
 
   addWordToBlacklist(wordToBeBlacklisted){
-    if (wordToBeBlacklisted.indexOf(' ') > 0) {
-        alert('Please select a single word only. Phrases such as: "' + wordToBeBlacklisted + '" aren\'t allowed');
-        return;
+
+    if (checkIfWordCountNotOne(wordToBeBlacklisted)){
+      return;
     }
+
+    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
+
     chrome.storage.local.get('userBlacklistedWords', function(result) {
       var currentUserBlacklistedWords = result.userBlacklistedWords;
       var blacklistedWords = [];
@@ -75,9 +114,12 @@ export class ContextMenu {
       }
       chrome.storage.local.set({'userBlacklistedWords': updatedBlacklistedWords});
     });
+
   }
 
   speakTheWord(utterance){
+    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
+
     chrome.storage.local.get(null, (data) => {
       var playbackOptions = JSON.parse(data.playbackOptions);
       chrome.tts.speak(utterance, {
@@ -87,6 +129,41 @@ export class ContextMenu {
               volume: parseFloat(playbackOptions.volume),
           }
       );
+    });
+  }
+
+  addToDifficultyBucket(word, difficultyLevel){
+    //TODO: put a check to see if there is only 1 word in the selection
+    // to check if only the translated word has been selected
+
+    if (checkIfWordCountNotOne(word)){
+      return;
+    }
+
+    if(currentURLIsBlacklistedOrMTWIsOff()){
+      return;
+    }
+
+    // Hash storage format:
+    // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
+    // E -> easy, N -> normal, H -> hard
+
+    chrome.storage.local.get(['difficultyBuckets','targetLanguage'], function(result) {
+      if (result.targetLanguage){
+        var currentBuckets = JSON.parse(result.difficultyBuckets);
+        var targetLang = result.targetLanguage;
+        var targetLangWordBucket = currentBuckets[targetLang];
+        var updatedBuckets = currentBuckets;
+        if (targetLangWordBucket){
+          targetLangWordBucket[word] = difficultyLevel;
+        }
+        else{
+          targetLangWordBucket = {}
+          targetLangWordBucket[word] = difficultyLevel;
+        }
+        updatedBuckets[targetLang] = targetLangWordBucket;
+        chrome.storage.local.set({'difficultyBuckets': JSON.stringify(updatedBuckets)});
+      }
     });
   }
 

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -1,4 +1,4 @@
-function checkIfWordCountNotOne(inputString){
+function _checkIfWordCountNotOne(inputString){
     var s = inputString;
     s = s.replace(/(^\s*)|(\s*$)/gi,"");
     s = s.replace(/[ ]{2,}/gi," ");
@@ -10,45 +10,49 @@ function checkIfWordCountNotOne(inputString){
     return false;
 }
 
-function currentURLIsBlacklistedOrMTWIsOff() {
-    var blacklistWebsiteReg, activation;
-    chrome.storage.local.get(['activation', 'blacklist'], function(result) {
-      blacklistWebsiteReg = new RegExp(result.blacklist);
-      activation = result.activation;
-    });
+function _currentURLIsBlacklistedOrMTWIsOff(documentURL) {
+    var promise = new Promise(function(resolve, reject) {
+      chrome.storage.local.get(['activation', 'blacklist'], function(result) {
+        var blacklistWebsiteReg = new RegExp(result.blacklist);
+        var activation = result.activation;
+        if (activation == false) {
+          alert('MindTheWord is switched off');
+          reject();
+        }
+        else if (blacklistWebsiteReg.test(documentURL)) {
+          alert('Current website is blacklisted');
+          reject();
+        }
+        else {
+          resolve();
+        }
+      })
+    })
 
-    if (!activation){
-      alert('MindTheWord is switched off');
-      return true;
-    }
-    else if (blacklistWebsiteReg.test(document.URL)){
-      alert('Current website is blacklisted');
-      return true;
-    }
-    else{
-      return false;
-    }
+    return promise;
 }
 
 export class ContextMenu {
 
   constructor(){}
 
-  searchForSimilarWords(selectedText, searchPlatform ) {
-  if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
-    var searchPlatformURLS = {
-      'bing': 'http://www.bing.com/search?q=%s+synonyms&go=&qs=n&sk=&sc=8-9&form=QBLH',
-      'google': 'http://www.google.com/#q=%s+synonyms&fp=1',
-      'googleImages': 'http://www.google.com/search?num=10&hl=en&site=imghp&tbm=isch&source=hp&q=%s',
-      'thesaurus': 'http://www.thesaurus.com/browse/%s?s=t'
-    }
-    var searchUrl = searchPlatformURLS[searchPlatform];
-    selectedText = selectedText.replace(" ", "+");
-    searchUrl = searchUrl.replace(/%s/g, selectedText);
-    chrome.tabs.create({
-       "url":searchUrl
+  searchForSimilarWords(selectedText, searchPlatform, tabURL ) {
+    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+      var searchPlatformURLS = {
+        'bing': 'http://www.bing.com/search?q=%s+synonyms&go=&qs=n&sk=&sc=8-9&form=QBLH',
+        'google': 'http://www.google.com/#q=%s+synonyms&fp=1',
+        'googleImages': 'http://www.google.com/search?num=10&hl=en&site=imghp&tbm=isch&source=hp&q=%s',
+        'thesaurus': 'http://www.thesaurus.com/browse/%s?s=t'
+      }
+      var searchUrl = searchPlatformURLS[searchPlatform];
+      selectedText = selectedText.replace(" ", "+");
+      searchUrl = searchUrl.replace(/%s/g, selectedText);
+      chrome.tabs.create({
+         "url":searchUrl
+      });
+    }, function(data){
+      //promise rejected
     });
-
   }
 
   searchForWordUsageExamples(selectedText, searchPlatform ) {
@@ -66,105 +70,120 @@ export class ContextMenu {
   }
 
   addUrlToBlacklist(tabURL){
-    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
-
-    var updatedBlacklist;
-    chrome.storage.local.get('blacklist', function(result) {
-      var currentBlacklist = result.blacklist;
-      var blacklistURLs = [];
-      blacklistURLs = currentBlacklist.slice(1, -1).split('|');
-      var re = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/im;
-      var domainNameFromTabURL = tabURL.match(re)[0];
-      //to avoid duplication
-      updatedBlacklist = '';
-      if (blacklistURLs.indexOf(domainNameFromTabURL + '*') == -1) {
-        //incase of empty current black list
-        if (!currentBlacklist) {
-          updatedBlacklist = '(' + domainNameFromTabURL + '*)';
-        } else {
-          updatedBlacklist = currentBlacklist.split(')')[0] + '|' + domainNameFromTabURL + '*)';
-        }
-      }
-      chrome.storage.local.set({'blacklist': updatedBlacklist});
-    });
-
-  }
-
-  addWordToBlacklist(wordToBeBlacklisted){
-
-    if (checkIfWordCountNotOne(wordToBeBlacklisted)){
-      return;
-    }
-
-    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
-
-    chrome.storage.local.get('userBlacklistedWords', function(result) {
-      var currentUserBlacklistedWords = result.userBlacklistedWords;
-      var blacklistedWords = [];
-      blacklistedWords =  currentUserBlacklistedWords.slice(1,-1).split('|');
-      var updatedBlacklistedWords = '';
-      //to avoid duplication
-      if (blacklistedWords.indexOf(wordToBeBlacklisted) == -1) {
-        //incase of empty current black list
-        if (!currentUserBlacklistedWords) {
-          updatedBlacklistedWords = '(' +  wordToBeBlacklisted + ')';
-        } else {
-          updatedBlacklistedWords = currentUserBlacklistedWords.split(')')[0] + '|' + wordToBeBlacklisted + ')';
-        }
-      }
-      chrome.storage.local.set({'userBlacklistedWords': updatedBlacklistedWords});
-    });
-
-  }
-
-  speakTheWord(utterance){
-    if (currentURLIsBlacklistedOrMTWIsOff()) {return;}
-
-    chrome.storage.local.get(null, (data) => {
-      var playbackOptions = JSON.parse(data.playbackOptions);
-      chrome.tts.speak(utterance, {
-              voiceName: playbackOptions.voiceName,
-              rate: parseFloat(playbackOptions.rate),
-              pitch: parseFloat(playbackOptions.pitch),
-              volume: parseFloat(playbackOptions.volume),
+    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+      var updatedBlacklist;
+      chrome.storage.local.get('blacklist', function(result) {
+        var currentBlacklist = result.blacklist;
+        var blacklistURLs = [];
+        blacklistURLs = currentBlacklist.slice(1, -1).split('|');
+        var re = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/im;
+        var domainNameFromTabURL = tabURL.match(re)[0];
+        //to avoid duplication
+        updatedBlacklist = '';
+        if (blacklistURLs.indexOf(domainNameFromTabURL + '*') == -1) {
+          //incase of empty current black list
+          if (!currentBlacklist) {
+            updatedBlacklist = '(' + domainNameFromTabURL + '*)';
+          } else {
+            updatedBlacklist = currentBlacklist.split(')')[0] + '|' + domainNameFromTabURL + '*)';
           }
-      );
+        }
+        chrome.storage.local.set({'blacklist': updatedBlacklist});
+      });
+    }, function(data){
+      //promise rejected
     });
   }
 
-  addToDifficultyBucket(word, difficultyLevel){
-    //TODO: put a check to see if there is only 1 word in the selection
-    // to check if only the translated word has been selected
+  addWordToBlacklist(wordToBeBlacklisted, tabURL){
 
-    if (checkIfWordCountNotOne(word)){
+    if (_checkIfWordCountNotOne(wordToBeBlacklisted)){
       return;
     }
 
-    if(currentURLIsBlacklistedOrMTWIsOff()){
-      return;
-    }
-
-    // Hash storage format:
-    // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
-    // E -> easy, N -> normal, H -> hard
-
-    chrome.storage.local.get(['difficultyBuckets','targetLanguage'], function(result) {
-      if (result.targetLanguage){
-        var currentBuckets = JSON.parse(result.difficultyBuckets);
-        var targetLang = result.targetLanguage;
-        var targetLangWordBucket = currentBuckets[targetLang];
-        var updatedBuckets = currentBuckets;
-        if (targetLangWordBucket){
-          targetLangWordBucket[word] = difficultyLevel;
+    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+      chrome.storage.local.get('userBlacklistedWords', function(result) {
+        var currentUserBlacklistedWords = result.userBlacklistedWords;
+        var blacklistedWords = [];
+        blacklistedWords =  currentUserBlacklistedWords.slice(1,-1).split('|');
+        var updatedBlacklistedWords = '';
+        //to avoid duplication
+        if (blacklistedWords.indexOf(wordToBeBlacklisted) == -1) {
+          //incase of empty current black list
+          if (!currentUserBlacklistedWords) {
+            updatedBlacklistedWords = '(' +  wordToBeBlacklisted + ')';
+          } else {
+            updatedBlacklistedWords = currentUserBlacklistedWords.split(')')[0] + '|' + wordToBeBlacklisted + ')';
+          }
         }
-        else{
-          targetLangWordBucket = {}
-          targetLangWordBucket[word] = difficultyLevel;
-        }
-        updatedBuckets[targetLang] = targetLangWordBucket;
-        chrome.storage.local.set({'difficultyBuckets': JSON.stringify(updatedBuckets)});
-      }
+        chrome.storage.local.set({'userBlacklistedWords': updatedBlacklistedWords});
+      });
+    }, function(data){
+      //promise rejected
     });
+  }
+
+  speakTheWord(utterance, tabURL){
+    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+      chrome.storage.local.get(null, (data) => {
+        var playbackOptions = JSON.parse(data.playbackOptions);
+        chrome.tts.speak(utterance, {
+                voiceName: playbackOptions.voiceName,
+                rate: parseFloat(playbackOptions.rate),
+                pitch: parseFloat(playbackOptions.pitch),
+                volume: parseFloat(playbackOptions.volume),
+            }
+        );
+      });
+    }, function(data){
+      //promise reject
+    });
+  }
+
+  addToDifficultyBucket(word, difficultyLevel, translatedWords, tabURL){
+
+    if (_checkIfWordCountNotOne(word)){return;}
+
+    //to check if the selected word is one of the translated words
+    var isTranslatedWord = false;
+    for (var k in translatedWords) {
+      if (translatedWords[k] === word) {
+        isTranslatedWord = true;
+        break;
+      }
+    }
+
+    if (isTranslatedWord){
+      _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+
+        // Hash storage format:
+        // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
+        // E -> easy, N -> normal, H -> hard
+
+        chrome.storage.local.get(['difficultyBuckets','targetLanguage'], function(result) {
+          if (result.targetLanguage){
+            var currentBuckets = JSON.parse(result.difficultyBuckets);
+            var targetLang = result.targetLanguage;
+            var targetLangWordBucket = currentBuckets[targetLang];
+            var updatedBuckets = currentBuckets;
+            if (targetLangWordBucket){
+              targetLangWordBucket[word] = difficultyLevel;
+            }
+            else{
+              targetLangWordBucket = {}
+              targetLangWordBucket[word] = difficultyLevel;
+            }
+            updatedBuckets[targetLang] = targetLangWordBucket;
+            chrome.storage.local.set({'difficultyBuckets': JSON.stringify(updatedBuckets)});
+          }
+        });
+      }, function(data){
+        //promise reject
+      });
+    }
+    else {
+        alert('Select one of the translated words');
+    }
   }
 
 }

--- a/lib/views/options.html
+++ b/lib/views/options.html
@@ -155,6 +155,17 @@
                     <span style="{{opctrl.translatedWordStyle}}">awesome</span>
                     style!
                   </p>
+                  <small>
+                    <span class="label label-danger">Note:</span>
+                    <span style = "color: rgba(75, 174, 79, 1.00);">Green, </span>
+                    <span style = "color: rgba(164, 59, 64, 1.00);">Mexican Red</span>
+                    and <span style = "color: rgba(243, 66, 53, 1.00);">Red</span>
+                    have been reserved for words in
+                    <span style = "color: rgba(75, 174, 79, 1.00);"> easy,</span>
+                    <span style = "color: rgba(164, 59, 64, 1.00);"> normal</span>
+                    and <span style = "color: rgba(243, 66, 53, 1.00);"> hard </span>
+                    buckets respectively
+                  </small>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Now words can be put into different difficulty level buckets, this will help the user differentiate between the words he should concentrate on and the ones he knows well

Three colors have been reserved for the easy, normal and difficult buckets:
<img width="428" alt="screen shot 2016-06-09 at 12 10 13 am" src="https://cloud.githubusercontent.com/assets/2452426/15906464/91d2aa6e-2dd6-11e6-8b86-5434f734aac4.png">

The user can select the word and chose which bucket to put it into using the context menu: 
<img width="1006" alt="screen shot 2016-06-08 at 11 41 11 pm" src="https://cloud.githubusercontent.com/assets/2452426/15906482/a55f0794-2dd6-11e6-8311-fbe96c0c7ae2.png">

Next time when the words appear, they will appear in their respective difficulty colors: 
<img width="726" alt="screen shot 2016-06-08 at 11 40 56 pm" src="https://cloud.githubusercontent.com/assets/2452426/15906470/9894d548-2dd6-11e6-9556-442908a66137.png">


