### PR TITLE
Auto disable context menu

### DIFF
--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -1,14 +1,10 @@
-import {BingTranslate} from './services/bingTranslate'
-import {ContextMenu} from './services/contextMenu'
+import { ContextMenu } from './services/contextMenu'
 
-console.log('eventPage running');
-
- var contextMenuFeatures = new ContextMenu(),
- translatedWords;
+var contextMenu = new ContextMenu(),
+  translatedWords;
 
 //sets up default data in localStorage
 function setupDefaultData() {
-  console.log('Initializing Local Storage');
   var localData = {
     initialized: true,
     activation: true,
@@ -45,7 +41,7 @@ function setupDefaultData() {
 }
 
 //On first installation, load default Data and initialize context menu
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(() => {
   setupDefaultData();
   chrome.contextMenus.create({
     'title': 'MindTheWord',
@@ -155,78 +151,89 @@ chrome.runtime.onInstalled.addListener(function() {
   });
 });
 
-function getCurrentTabURL(){
-  var promise = new Promise(function(resolve, reject){
-    chrome.tabs.query({currentWindow: true, active: true}, function(tabs){
-        resolve(tabs[0].url);
+function getCurrentTabURL() {
+  var promise = new Promise(function(resolve, reject) {
+    chrome.tabs.query({
+      currentWindow: true,
+      active: true
+    }, function(tabs) {
+      resolve(tabs[0].url);
     });
   })
 }
 
 // context menu handlers
 chrome.contextMenus.onClicked.addListener(onClickHandler);
+
 function onClickHandler(info, tab) {
-  chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
+  chrome.tabs.query({
+    currentWindow: true,
+    active: true
+  }, function(tabs) {
     var tabURL = tabs[0].url;
     if (info.menuItemId == "blacklistWebsite") {
-      contextMenuFeatures.addUrlToBlacklist(tabURL);
+      contextMenu.addUrlToBlacklist(tabURL);
     } else if (info.menuItemId == "blacklistWord") {
-      contextMenuFeatures.addWordToBlacklist(info.selectionText, tabURL);
+      contextMenu.addWordToBlacklist(info.selectionText, tabURL);
     } else if (info.menuItemId === "saveWord") {
-        // selectedText = info.selectionText;
-        // var translation = currentTranslatedMap[selectedText];
-        // if (currentTranslatedMap[selectedText]) {
-        //   console.log('To save:' + selectedText);
-        //   chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
-        // }
-        // else {
-        //   alert('Please select translated word. "' + selectedText + '" is not translated.'  );
-        // }
-    }
-    else if (info.menuItemId === "searchForSimilarWordsOnThesaurus"){
-      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'thesaurus', tabURL);
-    }
-    else if (info.menuItemId === "searchForSimilarWordsOnGoogle"){
-      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'google', tabURL);
-    }
-    else if (info.menuItemId === "searchForSimilarWordsOnBing"){
-      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'bing', tabURL);
-    }
-    else if (info.menuItemId === "searchForSimilarWordsOnGoogleImages"){
-      contextMenuFeatures.searchForSimilarWords(info.selectionText, 'googleImages', tabURL);
-    }
-    else if (info.menuItemId === "speakTheWord"){
-      contextMenuFeatures.speakTheWord(info.selectionText, tabURL);
-    }
-    else if (info.menuItemId === "addToDifficultyBucketEasy"){
-      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
-          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
+      selectedText = info.selectionText;
+      var translation = currentTranslatedMap[selectedText];
+      if (currentTranslatedMap[selectedText]) {
+        console.log('To save:' + selectedText);
+        chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
+      }
+      else {
+        alert('Please select translated word. "' + selectedText + '" is not translated.'  );
+      }
+    } else if (info.menuItemId === "searchForSimilarWordsOnThesaurus") {
+      contextMenu.searchForSimilarWords(info.selectionText, 'thesaurus', tabURL);
+    } else if (info.menuItemId === "searchForSimilarWordsOnGoogle") {
+      contextMenu.searchForSimilarWords(info.selectionText, 'google', tabURL);
+    } else if (info.menuItemId === "searchForSimilarWordsOnBing") {
+      contextMenu.searchForSimilarWords(info.selectionText, 'bing', tabURL);
+    } else if (info.menuItemId === "searchForSimilarWordsOnGoogleImages") {
+      contextMenu.searchForSimilarWords(info.selectionText, 'googleImages', tabURL);
+    } else if (info.menuItemId === "speakTheWord") {
+      contextMenu.speakTheWord(info.selectionText, tabURL);
+    } else if (info.menuItemId === "addToDifficultyBucketEasy") {
+      chrome.tabs.query({
+        active: true,
+        currentWindow: true
+      }, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          type: 'getTranslatedWords'
+        }, function(response) {
+          contextMenu.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
         });
       });
-    }
-    else if (info.menuItemId === "addToDifficultyBucketNormal"){
-      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
-          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
+    } else if (info.menuItemId === "addToDifficultyBucketNormal") {
+      chrome.tabs.query({
+        active: true,
+        currentWindow: true
+      }, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          type: 'getTranslatedWords'
+        }, function(response) {
+          contextMenu.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
         });
       });
-    }
-    else if (info.menuItemId === "addToDifficultyBucketHard"){
-      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
-          contextMenuFeatures.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
+    } else if (info.menuItemId === "addToDifficultyBucketHard") {
+      chrome.tabs.query({
+        active: true,
+        currentWindow: true
+      }, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          type: 'getTranslatedWords'
+        }, function(response) {
+          contextMenu.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
         });
       });
-    }
-    else if (info.menuItemId === "wordUsageExamplesYourDictionary"){
-      contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'yourdictionary.com' ,tabURL);
-    }
-    else if (info.menuItemId === "wordUsageExamplesManyThings"){
-      contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'manythings.org' ,tabURL);
-    }
-    else if (info.menuItemId === "wordUsageExamplesUseInASentence"){
-      contextMenuFeatures.searchForWordUsageExamples(info.selectionText, 'use-in-a-sentence.com' ,tabURL);
+    } else if (info.menuItemId === "wordUsageExamplesYourDictionary") {
+      contextMenu.searchForWordUsageExamples(info.selectionText, 'yourdictionary.com', tabURL);
+    } else if (info.menuItemId === "wordUsageExamplesManyThings") {
+      contextMenu.searchForWordUsageExamples(info.selectionText, 'manythings.org', tabURL);
+    } else if (info.menuItemId === "wordUsageExamplesUseInASentence") {
+      contextMenu.searchForWordUsageExamples(info.selectionText, 'use-in-a-sentence.com', tabURL);
     }
   });
 }

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -1,6 +1,4 @@
-import {
-  ContextMenu
-} from './services/contextMenu'
+import { ContextMenu } from './services/contextMenu'
 
 var contextMenu = new ContextMenu(),
   translatedWords = {};
@@ -241,14 +239,18 @@ function contextMenuClickHandler(info, tab) {
  * Disable context menu
  */
 function disableContextMenus() {
-  chrome.contextMenus.update('parent', {enabled: false});
+  chrome.contextMenus.update('parent', {
+    enabled: false
+  });
 }
 
 /**
  * Enable context Menu
  */
 function enableContextMenus() {
-  chrome.contextMenus.update('parent', {enabled: true});
+  chrome.contextMenus.update('parent', {
+    enabled: true
+  });
 }
 
 /**

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -197,10 +197,10 @@ function contextMenuClickHandler(info, tab) {
         active: true,
         currentWindow: true
       }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, {
-          type: 'getTranslatedWords'
-        }, (response) => {
-          contextMenu.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, (response) => {
+          if (response) {
+            contextMenu.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
+          }
         });
       });
     } else if (info.menuItemId === "addToDifficultyBucketNormal") {
@@ -208,10 +208,10 @@ function contextMenuClickHandler(info, tab) {
         active: true,
         currentWindow: true
       }, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {
-          type: 'getTranslatedWords'
-        }, (response) => {
-          contextMenu.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, (response) => {
+          if (response) {
+            contextMenu.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
+          }
         });
       });
     } else if (info.menuItemId === "addToDifficultyBucketHard") {
@@ -219,10 +219,10 @@ function contextMenuClickHandler(info, tab) {
         active: true,
         currentWindow: true
       }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, {
-          type: 'getTranslatedWords'
-        }, (response) => {
-          contextMenu.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
+        chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, (response) => {
+          if (response) {
+            contextMenu.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
+          }
         });
       });
     } else if (info.menuItemId === "wordUsageExamplesYourDictionary") {

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -1,11 +1,15 @@
-import { ContextMenu } from './services/contextMenu'
+import {
+  ContextMenu
+} from './services/contextMenu'
 
 var contextMenu = new ContextMenu(),
-  translatedWords;
+  translatedWords = {};
 
-//sets up default data in localStorage
-function setupDefaultData() {
-  var localData = {
+/**
+ * Set up default data and store it in `chrome.storage.localData`
+ */
+function initializeLocalStorage() {
+  let localData = {
     initialized: true,
     activation: true,
     blacklist: '(stackoverflow.com|github.com|code.google.com|developer.*.com|duolingo.com)',
@@ -40,9 +44,11 @@ function setupDefaultData() {
   chrome.storage.local.set(localData);
 }
 
-//On first installation, load default Data and initialize context menu
-chrome.runtime.onInstalled.addListener(() => {
-  setupDefaultData();
+/**
+ * Setup local data storage and context menus
+ */
+function setup() {
+  initializeLocalStorage();
   chrome.contextMenus.create({
     'title': 'MindTheWord',
     'id': 'parent',
@@ -63,6 +69,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     'title': 'Blacklist this website',
     'parentId': 'parent',
+    'contexts': ['page', 'selection'],
     'id': 'blacklistWebsite'
   });
   chrome.contextMenus.create({
@@ -149,42 +156,34 @@ chrome.runtime.onInstalled.addListener(() => {
     'contexts': ['selection'],
     'id': 'addToDifficultyBucketHard'
   });
-});
-
-function getCurrentTabURL() {
-  var promise = new Promise(function(resolve, reject) {
-    chrome.tabs.query({
-      currentWindow: true,
-      active: true
-    }, function(tabs) {
-      resolve(tabs[0].url);
-    });
-  })
 }
 
-// context menu handlers
-chrome.contextMenus.onClicked.addListener(onClickHandler);
-
-function onClickHandler(info, tab) {
+/**
+ * Click event handler for context menu. Calls appropriate
+ * functions from ContextMenu class.
+ * @param {Object} info -
+ * @param {Object} tabs -
+ */
+function contextMenuClickHandler(info, tab) {
   chrome.tabs.query({
     currentWindow: true,
     active: true
-  }, function(tabs) {
+  }, (tabs) => {
     var tabURL = tabs[0].url;
     if (info.menuItemId == "blacklistWebsite") {
       contextMenu.addUrlToBlacklist(tabURL);
     } else if (info.menuItemId == "blacklistWord") {
       contextMenu.addWordToBlacklist(info.selectionText, tabURL);
     } else if (info.menuItemId === "saveWord") {
-      selectedText = info.selectionText;
-      var translation = currentTranslatedMap[selectedText];
-      if (currentTranslatedMap[selectedText]) {
-        console.log('To save:' + selectedText);
-        chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
-      }
-      else {
-        alert('Please select translated word. "' + selectedText + '" is not translated.'  );
-      }
+      // selectedText = info.selectionText;
+      // var translation = currentTranslatedMap[selectedText];
+      // if (currentTranslatedMap[selectedText]) {
+      //   console.log('To save:' + selectedText);
+      //   chrome.runtime.sendMessage({updateUserDictionary: 'Add word to dictionary', word: selectedText, translation: translation}, function(r) {});
+      // }
+      // else {
+      //   alert('Please select translated word. "' + selectedText + '" is not translated.'  );
+      // }
     } else if (info.menuItemId === "searchForSimilarWordsOnThesaurus") {
       contextMenu.searchForSimilarWords(info.selectionText, 'thesaurus', tabURL);
     } else if (info.menuItemId === "searchForSimilarWordsOnGoogle") {
@@ -199,10 +198,10 @@ function onClickHandler(info, tab) {
       chrome.tabs.query({
         active: true,
         currentWindow: true
-      }, function(tabs) {
+      }, (tabs) => {
         chrome.tabs.sendMessage(tabs[0].id, {
           type: 'getTranslatedWords'
-        }, function(response) {
+        }, (response) => {
           contextMenu.addToDifficultyBucket(info.selectionText, 'e', response.translatedWords, tabURL);
         });
       });
@@ -213,7 +212,7 @@ function onClickHandler(info, tab) {
       }, function(tabs) {
         chrome.tabs.sendMessage(tabs[0].id, {
           type: 'getTranslatedWords'
-        }, function(response) {
+        }, (response) => {
           contextMenu.addToDifficultyBucket(info.selectionText, 'n', response.translatedWords, tabURL);
         });
       });
@@ -221,10 +220,10 @@ function onClickHandler(info, tab) {
       chrome.tabs.query({
         active: true,
         currentWindow: true
-      }, function(tabs) {
+      }, (tabs) => {
         chrome.tabs.sendMessage(tabs[0].id, {
           type: 'getTranslatedWords'
-        }, function(response) {
+        }, (response) => {
           contextMenu.addToDifficultyBucket(info.selectionText, 'h', response.translatedWords, tabURL);
         });
       });
@@ -238,6 +237,80 @@ function onClickHandler(info, tab) {
   });
 }
 
-// google_analytics('UA-1471148-13');
+/**
+ * Disable context menu
+ */
+function disableContextMenus() {
+  chrome.contextMenus.update('parent', {enabled: false});
+}
 
-console.log('eventPage ended');
+/**
+ * Enable context Menu
+ */
+function enableContextMenus() {
+  chrome.contextMenus.update('parent', {enabled: true});
+}
+
+/**
+ * Update context menu according to page
+ * @param {string} url - active tab URL
+ */
+function updateContextMenu(url) {
+  chrome.storage.local.get(['activation', 'blacklist'], (result) => {
+    var blacklistWebsiteReg = new RegExp(result.blacklist),
+      activation = result.activation;
+    if (activation == false) {
+      disableContextMenus();
+    } else if (blacklistWebsiteReg.test(url)) {
+      disableContextMenus();
+    } else if (/^\s*$/.test(url) === true) {
+      disableContextMenus();
+    } else {
+      enableContextMenus();
+    }
+  });
+}
+
+/**
+ * Checks if URL is changed. Call `updateContextMenu` if
+ * new URL is not blank or chrome URL.
+ * @param {Integer} tabId - tab identifier
+ * @param {Object} changeInfo - change information
+ * @param {Object} tab - tab information
+ */
+function checkURLChange(tabId, changeInfo, tab) {
+  if (changeInfo.url) {
+    if (changeInfo.url.indexOf('chrome://') === -1) {
+      updateContextMenu(changeInfo.url);
+    } else {
+      disableContextMenus();
+    }
+  }
+}
+
+/**
+ * Checks the current active tab has a valid URL and
+ * calls `updateContextMenu` if true.
+ * @param {Object} activeInfo - information about active tab
+ */
+function checkActiveTabChange(activeInfo) {
+  chrome.tabs.get(activeInfo.tabId, (tab) => {
+    if (tab.url.indexOf('chrome://') === -1) {
+      updateContextMenu(tab.url);
+    } else {
+      disableContextMenus();
+    }
+  });
+}
+
+//On first installation, load default Data and initialize context menu
+chrome.runtime.onInstalled.addListener(setup);
+
+// context menu handlers
+chrome.contextMenus.onClicked.addListener(contextMenuClickHandler);
+
+// update context menu if URL is changed
+chrome.tabs.onUpdated.addListener(checkURLChange);
+
+// update context menu if active tab is changed
+chrome.tabs.onActivated.addListener(checkActiveTabChange);

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -1,152 +1,115 @@
-function _checkIfWordCountNotOne(inputString){
-    var s = inputString;
-    s = s.replace(/(^\s*)|(\s*$)/gi,"");
-    s = s.replace(/[ ]{2,}/gi," ");
-    s = s.replace(/\n /,"\n");
-    if (s.split(' ').length != 1){
-        alert('Please select a single word only. Phrases such as: "' + inputString + '" aren\'t allowed');
-        return true;
-    }
-    return false;
-}
-
-function _currentURLIsBlacklistedOrMTWIsOff(documentURL) {
-    var promise = new Promise(function(resolve, reject) {
-      chrome.storage.local.get(['activation', 'blacklist'], function(result) {
-        var blacklistWebsiteReg = new RegExp(result.blacklist);
-        var activation = result.activation;
-        if (activation == false) {
-          alert('MindTheWord is switched off\n Please switch it on from the popup menu');
-          reject();
-        }
-        else if (blacklistWebsiteReg.test(documentURL)) {
-          alert('Current website is blacklisted\n You can unblacklist the website from the Advanced Settings tab in options');
-          reject();
-        }
-        else {
-          resolve();
-        }
-      })
-    })
-
-    return promise;
-}
-
 export class ContextMenu {
 
-  constructor(){}
+  constructor() {}
 
-  searchForSimilarWords(selectedText, searchPlatform, tabURL ) {
-    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
-      var searchPlatformURLS = {
-        'bing': 'http://www.bing.com/search?q=%s+synonyms&go=&qs=n&sk=&sc=8-9&form=QBLH',
-        'google': 'http://www.google.com/#q=%s+synonyms&fp=1',
-        'googleImages': 'http://www.google.com/search?num=10&hl=en&site=imghp&tbm=isch&source=hp&q=%s',
-        'thesaurus': 'http://www.thesaurus.com/browse/%s?s=t'
-      }
-      var searchUrl = searchPlatformURLS[searchPlatform];
-      selectedText = selectedText.replace(" ", "+");
-      searchUrl = searchUrl.replace(/%s/g, selectedText);
-      chrome.tabs.create({
-         "url":searchUrl
-      });
-    }, function(data){
-      //promise rejected
+  isWordCountNone(inputString) {
+    var s = inputString;
+    s = s.replace(/(^\s*)|(\s*$)/gi, "");
+    s = s.replace(/[ ]{2,}/gi, " ");
+    s = s.replace(/\n /, "\n");
+    if (s.split(' ').length != 1) {
+      alert('Please select a single word only. Phrases such as: "' + inputString + '" aren\'t allowed');
+      return true;
+    }
+    return false;
+  }
+
+  searchForSimilarWords(selectedText, searchPlatform, tabURL) {
+    var searchPlatformURLS = {
+      'bing': 'http://www.bing.com/search?q=%s+synonyms&go=&qs=n&sk=&sc=8-9&form=QBLH',
+      'google': 'http://www.google.com/#q=%s+synonyms&fp=1',
+      'googleImages': 'http://www.google.com/search?num=10&hl=en&site=imghp&tbm=isch&source=hp&q=%s',
+      'thesaurus': 'http://www.thesaurus.com/browse/%s?s=t'
+    }
+    var searchUrl = searchPlatformURLS[searchPlatform];
+    selectedText = selectedText.replace(" ", "+");
+    searchUrl = searchUrl.replace(/%s/g, selectedText);
+    chrome.tabs.create({
+      "url": searchUrl
     });
   }
 
   searchForWordUsageExamples(selectedText, searchPlatform, tabURL) {
-    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
-      var searchPlatformURLS = {
-        'yourdictionary.com': 'http://sentence.yourdictionary.com/%s',
-        'use-in-a-sentence.com': 'http://www.use-in-a-sentence.com/english-words/10000-words/%s.htm',
-        'manythings.org': 'http://www.manythings.org/sentences/words/%s/1.html'
-      }
-      var searchUrl = searchPlatformURLS[searchPlatform];
-      selectedText = selectedText.replace(" ", "+");
-      searchUrl = searchUrl.replace(/%s/g, selectedText);
-      chrome.tabs.create({
-         "url":searchUrl
-      });
-    }, function(data){
-      //promise rejected
+    var searchPlatformURLS = {
+      'yourdictionary.com': 'http://sentence.yourdictionary.com/%s',
+      'use-in-a-sentence.com': 'http://www.use-in-a-sentence.com/english-words/10000-words/%s.htm',
+      'manythings.org': 'http://www.manythings.org/sentences/words/%s/1.html'
+    }
+    var searchUrl = searchPlatformURLS[searchPlatform];
+    selectedText = selectedText.replace(" ", "+");
+    searchUrl = searchUrl.replace(/%s/g, selectedText);
+    chrome.tabs.create({
+      "url": searchUrl
     });
   }
 
-  addUrlToBlacklist(tabURL){
-    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
-      var updatedBlacklist;
-      chrome.storage.local.get('blacklist', function(result) {
-        var currentBlacklist = result.blacklist;
-        var blacklistURLs = [];
-        blacklistURLs = currentBlacklist.slice(1, -1).split('|');
-        var re = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/im;
-        var domainNameFromTabURL = tabURL.match(re)[0];
-        //to avoid duplication
-        updatedBlacklist = '';
-        if (blacklistURLs.indexOf(domainNameFromTabURL + '*') == -1) {
-          //incase of empty current black list
-          if (!currentBlacklist) {
-            updatedBlacklist = '(' + domainNameFromTabURL + '*)';
-          } else {
-            updatedBlacklist = currentBlacklist.split(')')[0] + '|' + domainNameFromTabURL + '*)';
-          }
+  addUrlToBlacklist(tabURL) {
+    var updatedBlacklist;
+    chrome.storage.local.get('blacklist', function(result) {
+      var currentBlacklist = result.blacklist;
+      var blacklistURLs = [];
+      blacklistURLs = currentBlacklist.slice(1, -1).split('|');
+      var re = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/im;
+      var domainNameFromTabURL = tabURL.match(re)[0];
+      //to avoid duplication
+      updatedBlacklist = '';
+      if (blacklistURLs.indexOf(domainNameFromTabURL + '*') == -1) {
+        //incase of empty current black list
+        if (!currentBlacklist) {
+          updatedBlacklist = '(' + domainNameFromTabURL + '*)';
+        } else {
+          updatedBlacklist = currentBlacklist.split(')')[0] + '|' + domainNameFromTabURL + '*)';
         }
-        chrome.storage.local.set({'blacklist': updatedBlacklist});
+      }
+      chrome.storage.local.set({
+        'blacklist': updatedBlacklist
       });
-    }, function(data){
-      //promise rejected
     });
   }
 
-  addWordToBlacklist(wordToBeBlacklisted, tabURL){
+  addWordToBlacklist(wordToBeBlacklisted, tabURL) {
 
-    if (_checkIfWordCountNotOne(wordToBeBlacklisted)){
+    if (this.isWordCountNone(wordToBeBlacklisted)) {
       return;
     }
 
-    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
-      chrome.storage.local.get('userBlacklistedWords', function(result) {
-        var currentUserBlacklistedWords = result.userBlacklistedWords;
-        var blacklistedWords = [];
-        blacklistedWords =  currentUserBlacklistedWords.slice(1,-1).split('|');
-        var updatedBlacklistedWords = '';
-        //to avoid duplication
-        if (blacklistedWords.indexOf(wordToBeBlacklisted) == -1) {
-          //incase of empty current black list
-          if (!currentUserBlacklistedWords) {
-            updatedBlacklistedWords = '(' +  wordToBeBlacklisted + ')';
-          } else {
-            updatedBlacklistedWords = currentUserBlacklistedWords.split(')')[0] + '|' + wordToBeBlacklisted + ')';
-          }
+    chrome.storage.local.get('userBlacklistedWords', function(result) {
+      var currentUserBlacklistedWords = result.userBlacklistedWords;
+      var blacklistedWords = [];
+      blacklistedWords = currentUserBlacklistedWords.slice(1, -1).split('|');
+      var updatedBlacklistedWords = '';
+      //to avoid duplication
+      if (blacklistedWords.indexOf(wordToBeBlacklisted) == -1) {
+        //incase of empty current black list
+        if (!currentUserBlacklistedWords) {
+          updatedBlacklistedWords = '(' + wordToBeBlacklisted + ')';
+        } else {
+          updatedBlacklistedWords = currentUserBlacklistedWords.split(')')[0] + '|' + wordToBeBlacklisted + ')';
         }
-        chrome.storage.local.set({'userBlacklistedWords': updatedBlacklistedWords});
+      }
+      chrome.storage.local.set({
+        'userBlacklistedWords': updatedBlacklistedWords
       });
-    }, function(data){
-      //promise rejected
     });
   }
 
-  speakTheWord(utterance, tabURL){
-    _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
-      chrome.storage.local.get(null, (data) => {
-        var playbackOptions = JSON.parse(data.playbackOptions);
-        chrome.tts.speak(utterance, {
-                voiceName: playbackOptions.voiceName,
-                rate: parseFloat(playbackOptions.rate),
-                pitch: parseFloat(playbackOptions.pitch),
-                volume: parseFloat(playbackOptions.volume),
-            }
-        );
+  speakTheWord(utterance, tabURL) {
+    chrome.storage.local.get(null, (data) => {
+      var playbackOptions = JSON.parse(data.playbackOptions);
+      chrome.tts.speak(utterance, {
+        voiceName: playbackOptions.voiceName,
+        rate: parseFloat(playbackOptions.rate),
+        pitch: parseFloat(playbackOptions.pitch),
+        volume: parseFloat(playbackOptions.volume),
       });
-    }, function(data){
-      //promise reject
     });
   }
 
-  addToDifficultyBucket(word, difficultyLevel, translatedWords, tabURL){
+  addToDifficultyBucket(word, difficultyLevel, translatedWords, tabURL) {
 
-    if (_checkIfWordCountNotOne(word)){return;}
+    if (this.isWordCountNone(word)) {
+      return;
+    }
 
     //to check if the selected word is one of the translated words
     var isTranslatedWord = false;
@@ -157,36 +120,32 @@ export class ContextMenu {
       }
     }
 
-    if (isTranslatedWord){
-      _currentURLIsBlacklistedOrMTWIsOff(tabURL).then(function(data){
+    if (isTranslatedWord) {
 
-        // Hash storage format:
-        // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
-        // E -> easy, N -> normal, H -> hard
+      // Hash storage format:
+      // format: {targetLanguage: {word1: E/N/H, word2: E/N/H}}
+      // E -> easy, N -> normal, H -> hard
 
-        chrome.storage.local.get(['difficultyBuckets','targetLanguage'], function(result) {
-          if (result.targetLanguage){
-            var currentBuckets = JSON.parse(result.difficultyBuckets);
-            var targetLang = result.targetLanguage;
-            var targetLangWordBucket = currentBuckets[targetLang];
-            var updatedBuckets = currentBuckets;
-            if (targetLangWordBucket){
-              targetLangWordBucket[word] = difficultyLevel;
-            }
-            else{
-              targetLangWordBucket = {}
-              targetLangWordBucket[word] = difficultyLevel;
-            }
-            updatedBuckets[targetLang] = targetLangWordBucket;
-            chrome.storage.local.set({'difficultyBuckets': JSON.stringify(updatedBuckets)});
+      chrome.storage.local.get(['difficultyBuckets', 'targetLanguage'], function(result) {
+        if (result.targetLanguage) {
+          var currentBuckets = JSON.parse(result.difficultyBuckets);
+          var targetLang = result.targetLanguage;
+          var targetLangWordBucket = currentBuckets[targetLang];
+          var updatedBuckets = currentBuckets;
+          if (targetLangWordBucket) {
+            targetLangWordBucket[word] = difficultyLevel;
+          } else {
+            targetLangWordBucket = {}
+            targetLangWordBucket[word] = difficultyLevel;
           }
-        });
-      }, function(data){
-        //promise reject
+          updatedBuckets[targetLang] = targetLangWordBucket;
+          chrome.storage.local.set({
+            'difficultyBuckets': JSON.stringify(updatedBuckets)
+          });
+        }
       });
-    }
-    else {
-        alert('Select one of the translated words');
+    } else {
+      alert('Select one of the translated words');
     }
   }
 


### PR DESCRIPTION
Context menus are disabled automatically for blacklisted pages, `chrome://` and blank URL pages. So we don't need to check `isValid` condition every time. 