### PR TITLE
Sentence translation

### DIFF
--- a/lib/assets/css/MTWStyles.css
+++ b/lib/assets/css/MTWStyles.css
@@ -1,0 +1,32 @@
+.noselect {
+  -webkit-user-select: none;
+}
+
+.popover {
+  position: absolute;
+  display: inline-block;
+  padding: 4px;
+  background-color: black;
+  color: white;
+  border-radius: 6px;
+  box-shadow: 2px 2px 10px black;
+  user-select: none;
+}
+
+span.mtwTranslatedWorde {
+  font-style: inherit;
+  color: rgba(86, 179, 90, 1.00);
+  background-color: white;
+}
+
+span.mtwTranslatedWordn {
+  font-style: inherit;
+  color: rgba(164, 59, 64, 1.00);
+  background-color: white;
+}
+
+span.mtwTranslatedWordh {
+  font-style: inherit;
+  color: rgba(209, 29, 29, 1.00);
+  background-color: white;
+}

--- a/lib/assets/css/MTWStyles.css
+++ b/lib/assets/css/MTWStyles.css
@@ -4,6 +4,7 @@
 
 .popover {
   position: absolute;
+  top: -50px;
   display: inline-block;
   padding: 4px;
   background-color: black;
@@ -11,6 +12,14 @@
   border-radius: 6px;
   box-shadow: 2px 2px 10px black;
   user-select: none;
+  white-space: nowrap;
+}
+
+.anchor {
+  position: relative;
+  width: auto;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 span.mtwTranslatedWorde {

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -156,10 +156,16 @@ function setup() {
     'id': 'addToDifficultyBucketHard'
   });
   chrome.contextMenus.create({
-    'title': 'Mark As Learnt',
+    'title': 'Mark as Learnt',
     'parentId': 'parent',
     'contexts': ['selection'],
     'id': 'markAsLearnt'
+  });
+  chrome.contextMenus.create({
+    'title': 'Translate Sentence',
+    'parentId': 'parent',
+    'contexts': ['selection'],
+    'id': 'translateSentence'
   });
 }
 
@@ -239,12 +245,33 @@ function contextMenuClickHandler(info, tab) {
       contextMenu.searchForWordUsageExamples(info.selectionText, 'manythings.org', tabURL);
     } else if (info.menuItemId === "wordUsageExamplesUseInASentence") {
       contextMenu.searchForWordUsageExamples(info.selectionText, 'use-in-a-sentence.com', tabURL);
-    } else if (info.menuItemId === "markAsLearnt"){
+    } else if (info.menuItemId === "markAsLearnt") {
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
         chrome.tabs.sendMessage(tabs[0].id, {type: 'getTranslatedWords'}, function(response){
             if (response) {
               contextMenu.markWordAsLearnt(info.selectionText, response.translatedWords, tabURL);
             }
+        });
+      });
+    } else if (info.menuItemId === "translateSentence") {
+      chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          type: 'getTranslatedWords',
+          action: 'storeSelection'
+        }, (response) => {
+          if (response) {
+            console.log(response);
+            contextMenu.translateSentence(info.selectionText, response.translatedWords)
+              .then((translationData) => {
+                chrome.tabs.sendMessage(tabs[0].id, {
+                  type: 'showTranslatedSentence',
+                  data: translationData
+                });
+              })
+              .catch((e) => {
+                console.error('Error in obtaining translations', e);
+              });
+          }
         });
       });
     }

--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -260,7 +260,6 @@ function contextMenuClickHandler(info, tab) {
           action: 'storeSelection'
         }, (response) => {
           if (response) {
-            console.log(response);
             contextMenu.translateSentence(info.selectionText, response.translatedWords)
               .then((translationData) => {
                 chrome.tabs.sendMessage(tabs[0].id, {

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -340,19 +340,19 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     }
     sendResponse({translatedWords: MTWTranslator.filteredTMap});
   } else if (request.type = 'showTranslatedSentence') {
-    let dummy = document.createElement("span"),
-      box = MTWTranslator.selectedRegion.getBoundingClientRect();
+    let anchor = document.createElement('span');
+    let dummy = document.createElement('span');
     dummy.innerText = JSON.parse(request.data).text[0];
-    dummy.style.top = box.top - 30;
-    dummy.style.left = box.left;
-    console.log(box);
-    MTWTranslator.selectedRegion.insertNode(dummy);
     dummy.classList.add('popover');
     dummy.classList.add('noselect');
-    // function handler(e) {
-    //   this.removeEventListener('mousedown', handler);
-    //   dummy.parentNode.removeChild(dummy);
-    // }
-    // window.addEventListener('mousedown', handler);
+    anchor.appendChild(dummy);
+    anchor.classList.add('anchor');
+    MTWTranslator.selectedRegion.insertNode(anchor);
+
+    function handler(e) {
+      this.removeEventListener('mousedown', handler);
+      anchor.parentNode.removeChild(anchor);
+    }
+    window.addEventListener('mousedown', handler);
   }
 });

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -342,7 +342,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   } else if (request.type = 'showTranslatedSentence') {
     let anchor = document.createElement('span');
     let dummy = document.createElement('span');
-    dummy.innerText = JSON.parse(request.data).text[0];
+    dummy.innerText = request.data;
     dummy.classList.add('popover');
     dummy.classList.add('noselect');
     anchor.appendChild(dummy);
@@ -350,9 +350,9 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     MTWTranslator.selectedRegion.insertNode(anchor);
 
     function handler(e) {
-      this.removeEventListener('mousedown', handler);
+      this.removeEventListener('click', handler);
       anchor.parentNode.removeChild(anchor);
     }
-    window.addEventListener('mousedown', handler);
+    window.addEventListener('click', handler);
   }
 });

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -2,16 +2,15 @@ import { YandexTranslate } from './services/yandexTranslate'
 import { BingTranslate } from './services/bingTranslate'
 import { GoogleTranslate } from './services/googleTranslate'
 
-//TODO: Change this into a class variable!
-var tMapForMessageResponse;
-
 export class ContentScript {
   constructor() {
     this.srcLang = '';
     this.targetLang = '';
     this.ngramMin = 1;
     this.ngramMax = 1;
-    this.tMap;
+    this.tMap = {};
+    this.filteredTMap = {};
+    this.selectedRegion = {};
   }
 
   translate() {
@@ -80,16 +79,19 @@ export class ContentScript {
     return translatorObject;
   }
 
+  /**
+   * For words belong to difficulty buckets
+   * difficultyLevels: e -> easy, n -> normal, h -> hard
+   * class name mtwTranslatedWord + difficultyLevel
+   */
   injectCSS(cssStyle) {
     try {
+      var style   = document.createElement('link');
+      style.rel   = 'stylesheet';
+      style.type  = 'text/css';
+      style.href  = chrome.extension.getURL('/assets/css/MTWStyles.css')
+      document.getElementsByTagName('head')[0].appendChild(style);
       document.styleSheets[0].insertRule('span.mtwTranslatedWord {' + cssStyle + '}', 0);
-
-      // For words belong to difficulty buckets
-      // difficultyLevels: e -> easy, n -> normal, h -> hard
-      // class name mtwTranslatedWord + difficultyLevel
-      document.styleSheets[0].insertRule('span.mtwTranslatedWorde {' + 'font-style: inherit;\ncolor: rgba(86, 179, 90, 1.00);\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
-      document.styleSheets[0].insertRule('span.mtwTranslatedWordn {' + 'font-style: inherit;\ncolor: rgba(164, 59, 64, 1.00);\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
-      document.styleSheets[0].insertRule('span.mtwTranslatedWordh {' + 'font-style: inherit;\ncolor: rgba(209, 29, 29, 1.00)\nbackground-color: rgba(255, 255, 255, 1.00);' + '}', 0);
     } catch (e) {
       console.debug(e);
     }
@@ -102,9 +104,8 @@ export class ContentScript {
   }
 
   getAllWords(ngramMin, ngramMax) {
-    console.log('getAllWords: ngramMin = ' + ngramMin + '; ngramMax = ' + ngramMax);
-    var countedWords = {};
-    var paragraphs = document.getElementsByTagName('p');
+    var countedWords = {},
+      paragraphs = document.getElementsByTagName('p');
     console.log('Getting words from all ' + paragraphs.length + ' paragraphs');
     for (var i = 0; i < paragraphs.length; i++) {
       var words = paragraphs[i].innerText.split(/\s|,|[.()]|\d/g);
@@ -173,7 +174,7 @@ export class ContentScript {
     }
 
     //for difficulty buckets feature
-    tMapForMessageResponse = filteredTMap;
+    this.filteredTMap = filteredTMap;
 
     if (Object.keys(filteredTMap).length !== 0) {
       var paragraphs = document.getElementsByTagName('p');
@@ -330,11 +331,28 @@ export class ContentScript {
 var MTWTranslator = new ContentScript();
 MTWTranslator.translate();
 
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if(request.type === 'toggleAllElements'){
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  if (request.type === 'toggleAllElements') {
     MTWTranslator.toggleAllElements();
-  }
-  else if(request.type === 'getTranslatedWords'){
-    sendResponse({translatedWords: tMapForMessageResponse});
+  } else if (request.type === 'getTranslatedWords') {
+    if (request.action === 'storeSelection') {
+      MTWTranslator.selectedRegion = window.getSelection().getRangeAt(0);
+    }
+    sendResponse({translatedWords: MTWTranslator.filteredTMap});
+  } else if (request.type = 'showTranslatedSentence') {
+    let dummy = document.createElement("span"),
+      box = MTWTranslator.selectedRegion.getBoundingClientRect();
+    dummy.innerText = JSON.parse(request.data).text[0];
+    dummy.style.top = box.top - 30;
+    dummy.style.left = box.left;
+    console.log(box);
+    MTWTranslator.selectedRegion.insertNode(dummy);
+    dummy.classList.add('popover');
+    dummy.classList.add('noselect');
+    // function handler(e) {
+    //   this.removeEventListener('mousedown', handler);
+    //   dummy.parentNode.removeChild(dummy);
+    // }
+    // window.addEventListener('mousedown', handler);
   }
 });

--- a/lib/scripts/services/bingTranslate.js
+++ b/lib/scripts/services/bingTranslate.js
@@ -85,4 +85,33 @@ export class BingTranslate {
 
     return tMap;
   }
+
+  translateSentence(text) {
+    var promise = new Promise((resolve, reject) => {
+      this.url = 'http://api.microsofttranslator.com/V2/Http.svc/Translate';
+      this.url += '?appId';
+      this.url += '&from=' + this.srcLang;
+      this.url += '&to=' + this.targetLang;
+      this.url += '&text=' + text;
+      let headers = {'content-type': 'application/x-www-form-urlencoded'}
+      http(this.authUrl)
+        .post(this.authData, headers)
+        .then((data) => {
+          headers = {
+            'Authorization': 'Bearer' + ' ' + JSON.parse(data).access_token
+          }
+          http(this.url)
+            .get({}, headers)
+            .then((res) => {
+              let xml = this.parseXML(res);
+              let sentence = xml.getElementsByTagName('string')[0].innerHTML;
+              resolve(sentence);
+            })
+            .catch((e) => {
+              reject(e);
+            });
+        })
+    });
+    return promise;
+  }
 }

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -1,4 +1,6 @@
 import { YandexTranslate } from './yandexTranslate'
+import { GoogleTranslate } from './googleTranslate'
+import { BingTranslate } from './bingTranslate'
 
 export class ContextMenu {
 
@@ -185,28 +187,24 @@ export class ContextMenu {
   }
 
   translateSentence(selectedText, translatedWords) {
-    var promise = new Promise(function(resolve, reject) {
-      let keys = ['translatorService',
+    var promise = new Promise((resolve, reject) => {
+      var keys = ['translatorService',
         'sourceLanguage',
         'targetLanguage',
         'yandexTranslatorApiKey',
         'googleTranslatorApiKey',
         'bingTranslatorApiKey'
       ];
-      let words = selectedText.split(' ');
-      if (words.length >= 2 && words.length < 20) {
-        // for (let i in words) {
-        //   if (typeof translatedWords.words[i] === undefined) {
-        //     for (let j in translatedWords) {
-        //       if (translatedWords.j === words[i]) {
-        //         words[i] = j;
-        //         break;
-        //       }
-        //     }
-        //   }
-        // }
+      var words = selectedText.split(' ');
+      var translations = Object.values(translatedWords);
+      var sourceWords = Object.keys(translatedWords);
+      if (words.length >= 2 && words.length < 14) {
+        for (var i in words) {
+          if (translations.indexOf(words[i]) > -1) {
+            words[i] = sourceWords[translations.indexOf(words[i])]
+          }
+        }
         selectedText = words.join(' ');
-        console.log(selectedText);
         chrome.storage.local.get(keys, (data) => {
           var promise = {};
           switch (data.translatorService) {
@@ -215,10 +213,12 @@ export class ContextMenu {
               promise = yandexTranslate.translateSentence(selectedText);
               break;
             case 'Bing':
-
+              let bingTranslate = new GoogleTranslate(data.bingTranslatorApiKey, data.sourceLanguage, data.targetLanguage)
+              promise = bingTranslate.translateSentence(selectedText);
               break;
             case 'Google':
-
+              let googleTranslate = new GoogleTranslate(data.googleTranslatorApiKey, data.sourceLanguage, data.targetLanguage);
+              promise = googleTranslate.translateSentence(selectedText);
               break;
             default:
           }
@@ -231,7 +231,7 @@ export class ContextMenu {
             });
         });
       } else {
-        alert('Select a sentence containing at least 3 words.')
+        alert('Select a sentence containing at least 3 words and at most 15 words.')
       }
     });
     return promise;

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -213,7 +213,7 @@ export class ContextMenu {
               promise = yandexTranslate.translateSentence(selectedText);
               break;
             case 'Bing':
-              let bingTranslate = new GoogleTranslate(data.bingTranslatorApiKey, data.sourceLanguage, data.targetLanguage)
+              let bingTranslate = new BingTranslate(data.bingTranslatorApiKey, data.sourceLanguage, data.targetLanguage)
               promise = bingTranslate.translateSentence(selectedText);
               break;
             case 'Google':

--- a/lib/scripts/services/contextMenu.js
+++ b/lib/scripts/services/contextMenu.js
@@ -1,3 +1,5 @@
+import { YandexTranslate } from './yandexTranslate'
+
 export class ContextMenu {
 
   constructor() {}
@@ -180,6 +182,59 @@ export class ContextMenu {
       alert('Select one of the translated words');
     }
 
+  }
+
+  translateSentence(selectedText, translatedWords) {
+    var promise = new Promise(function(resolve, reject) {
+      let keys = ['translatorService',
+        'sourceLanguage',
+        'targetLanguage',
+        'yandexTranslatorApiKey',
+        'googleTranslatorApiKey',
+        'bingTranslatorApiKey'
+      ];
+      let words = selectedText.split(' ');
+      if (words.length >= 2 && words.length < 20) {
+        // for (let i in words) {
+        //   if (typeof translatedWords.words[i] === undefined) {
+        //     for (let j in translatedWords) {
+        //       if (translatedWords.j === words[i]) {
+        //         words[i] = j;
+        //         break;
+        //       }
+        //     }
+        //   }
+        // }
+        selectedText = words.join(' ');
+        console.log(selectedText);
+        chrome.storage.local.get(keys, (data) => {
+          var promise = {};
+          switch (data.translatorService) {
+            case 'Yandex':
+              let yandexTranslate = new YandexTranslate(data.yandexTranslatorApiKey, data.sourceLanguage, data.targetLanguage);
+              promise = yandexTranslate.translateSentence(selectedText);
+              break;
+            case 'Bing':
+
+              break;
+            case 'Google':
+
+              break;
+            default:
+          }
+          promise
+            .then((translatedSentence) => {
+              resolve(translatedSentence);
+            })
+            .catch((e) => {
+              reject(e);
+            });
+        });
+      } else {
+        alert('Select a sentence containing at least 3 words.')
+      }
+    });
+    return promise;
   }
 
 }

--- a/lib/scripts/services/googleTranslate.js
+++ b/lib/scripts/services/googleTranslate.js
@@ -79,4 +79,20 @@ export class GoogleTranslate {
     console.log(tMap);
     return tMap;
   }
+
+  translateSentence(text) {
+    var promise = new Promise((resolve, reject) => {
+      this.url += '&source=' + this.srcLang + '&target=' + this.targetLang;
+      this.url += '&q=' + text;
+      http(this.url)
+        .get()
+        .then((data) => {
+          resolve(JSON.parse(data).data.translations[0].translatedText);
+        })
+        .catch((e) => {
+          reject(e);
+        });
+    });
+    return promise;
+  }
 }

--- a/lib/scripts/services/yandexTranslate.js
+++ b/lib/scripts/services/yandexTranslate.js
@@ -40,4 +40,20 @@ export class YandexTranslate {
     }
     return tMap;
   }
+
+  translateSentence(text) {
+    var promise = new Promise((resolve, reject) => {
+      this.url += '&lang=' + this.srcLang + '-' + this.targetLang;
+      this.url += '&text=' + text;
+      http(this.url)
+        .get()
+        .then((data) => {
+          resolve(data);
+        })
+        .catch((e) => {
+          reject(e);
+        });
+    });
+    return promise;
+  }
 }

--- a/lib/scripts/services/yandexTranslate.js
+++ b/lib/scripts/services/yandexTranslate.js
@@ -48,7 +48,7 @@ export class YandexTranslate {
       http(this.url)
         .get()
         .then((data) => {
-          resolve(data);
+          resolve(JSON.parse(data).text[0]);
         })
         .catch((e) => {
           reject(e);


### PR DESCRIPTION
This PR adds the following functionality:

1. **Sentence Translation:** User can select a sentence (3 - 15 words) and click `Translate Sentence` from context menu to get the translation of that sentence. This translation will be shown as a popover above the selection. It can be dismissed with a click.

2. **Modular CSS:** If any style has to injected in a webpage, it can be directly added to `MTWStyles.css`. This will be automatically added - no need for other injection.

### Screenshot

![sen_translate](https://cloud.githubusercontent.com/assets/9019878/15991568/de822a10-30d3-11e6-8020-9a46ff85d944.png)
