### PR TITLE
Minor fixes

### DIFF
--- a/lib/scripts/eventPage.js
+++ b/lib/scripts/eventPage.js
@@ -189,7 +189,7 @@ function updateContextMenu(url) {
  * @param {Object} tab - tab information
  */
 function checkURLChange(tabId, changeInfo, tab) {
-  if (changeInfo.url) {
+  if (changeInfo.url || changeInfo.status === 'complete') {
     if (/chrome.*\:\/\//.test(changeInfo.url) === false) {
       updateContextMenu(changeInfo.url);
     } else {

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -16,7 +16,6 @@ export class ContentScript {
 
   translate() {
     chrome.storage.local.get(null, (res) => {
-      console.log(res);
       if (res.activation === true) {
         this.ngramMin = res.ngramMin;
         this.ngramMax = res.ngramMax;
@@ -62,7 +61,6 @@ export class ContentScript {
               this.translationProbability,
               this.userDefinedTranslations,
               this.userBlacklistedWords);
-            console.log(filteredWords);
             var translator = this.getTranslator();
             translator.getTranslations(filteredWords)
               .then((tMap) => {
@@ -99,12 +97,18 @@ export class ContentScript {
 
   injectCSS(cssStyle) {
     try {
+      // insert MTW styles
       var style   = document.createElement('link');
       style.rel   = 'stylesheet';
       style.type  = 'text/css';
       style.href  = chrome.extension.getURL('/assets/css/MTWStyles.css');
       document.getElementsByTagName('head')[0].appendChild(style);
-      document.styleSheets[0].insertRule('span.mtwTranslatedWord {' + cssStyle + '}', 0);
+
+      // insert main mtwTranslatedWord stylesheet
+      var mtwStyle = document.createElement('style');
+      document.head.appendChild(mtwStyle);
+      mtwStyle.sheet.insertRule('span.mtwTranslatedWord {' + cssStyle + '}', 0);
+      
     } catch (e) {
       console.debug(e);
     }
@@ -339,7 +343,7 @@ export class ContentScript {
         iMap[map[e]] = iMap[map[e]] + '" class="mtwTranslatedWord"';
       }
       iMap[map[e]] = iMap[map[e]] +
-                    '">' + map[e] +
+                    '>' + map[e] +
                     '</span>';
     }
 

--- a/lib/scripts/services/yandexTranslate.js
+++ b/lib/scripts/services/yandexTranslate.js
@@ -31,8 +31,6 @@ export class YandexTranslate {
       i = 0,
       translatedWords = data.text;
 
-    console.log(words);
-    console.log(translatedWords);
     for (let word in words) {
       // add a try catch block
       tMap[word] = translatedWords[i];


### PR DESCRIPTION
Fix 2 bugs:

1. In pages which did not have any stylesheet (rather old ones), the translated words were not highlighted. 
2. On toggling the activation to 'Off' on any particular page, the context menu was not disabled.