### PR TITLE
fix empty replacements

### DIFF
--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -309,7 +309,7 @@ export class ContentScript {
   replaceAll(text, translationMap) {
     var rExp = '';
     var sortedSourceWords = Object.keys(translationMap)
-      .sort(function sortDescending(w1, w2) {
+      .sort((w1, w2) => {
         return w2.length - w1.length;
       });
     sortedSourceWords.forEach((sourceWord) => {
@@ -317,13 +317,16 @@ export class ContentScript {
     });
     rExp = rExp.substring(0, rExp.length - 1);
     var regExp = new RegExp(rExp, 'gm');
-    var newText = text.replace(regExp, function(m) {
+    var newText = text.replace(regExp, (m) => {
       if (translationMap[m.substring(1, m.length - 1)] !== null) {
         return ' ' + translationMap[m.substring(1, m.length - 1)] + ' ';
       } else {
         return ' ' + m + ' ';
       }
     });
+    if (/^\s*$/.test(newText)) {
+      return text;
+    }
     return newText;
   }
 
@@ -341,8 +344,7 @@ export class ContentScript {
       if(map[e] in parsedDifficultyBuckets) {
         var wordDifficultyLevel = parsedDifficultyBuckets[map[e]];
         iMap[map[e]] = iMap[map[e]] + '" class="mtwTranslatedWord' + wordDifficultyLevel + '"';
-      }
-      else {
+      } else {
         iMap[map[e]] = iMap[map[e]] + '" class="mtwTranslatedWord"';
       }
       iMap[map[e]] = iMap[map[e]] +


### PR DESCRIPTION
If an HTML tag (with nodetype `TEXT_NODE`) was passed to the function, it would replace it with a blank string. This led to data loss and UI breaks. This PR fixes the issue by adding a check for empty `newText` variable.