### PR TITLE
keys panel in advanced tab

### DIFF
--- a/lib/scripts/utils/defaultStorage.js
+++ b/lib/scripts/utils/defaultStorage.js
@@ -24,7 +24,7 @@ export var localData = {
   translatorService: 'Yandex',
   yandexTranslatorApiKey: '',
   googleTranslatorApiKey: '',
-  bingTranslatorApiKey: '',
+  bingTranslatorApiKey: {clientId: '', clientSecret: ''},
   playbackOptions: '{"volume": 1.0, "rate": 1.0, "voiceName": "Google US English", "pitch": 0.5 }',
   // format: {word1: E/N/H, word2: E/N/H}
   // E -> easy, N -> normal, H -> hard

--- a/lib/views/includes/advanced.html
+++ b/lib/views/includes/advanced.html
@@ -148,3 +148,34 @@
     </div>
   </div>
 </div>
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-danger">
+      <div class="panel-heading">
+        <span>Translator Keys</span>
+        <span class="glyphicon glyphicon-question-sign pull-right" data-toggle="tooltip" data-placement="bottom" title="Update Translator Keys"></span>
+      </div>
+      <div class="panel-body">
+        <div class="input-group">
+          <span class="input-group-addon">Google Key</span>
+          <input ng-model="opctrl.googleTranslatorApiKey" ng-blur="opctrl.save({'googleTranslatorApiKey': opctrl.googleTranslatorApiKey}, 'Updated')" type="text" id="key" class="form-control">
+        </div>
+        <br>
+        <div class="input-group">
+          <span class="input-group-addon">Yandex Key</span>
+          <input ng-model="opctrl.yandexTranslatorApiKey" ng-blur="opctrl.save({'yandexTranslatorApiKey': opctrl.yandexTranslatorApiKey}, 'Updated')" type="text" id="key" class="form-control">
+        </div>
+        <br>
+        <div class="input-group">
+          <span class="input-group-addon">Bing Client ID</span>
+          <input ng-model="opctrl.bingTranslatorApiKey.clientId" ng-blur="opctrl.save({'bingTranslatorApiKey': {clientSecret: opctrl.bingTranslatorApiKey.clientSecret, clientId: opctrl.bingTranslatorApiKey.clientId}}, 'Updated')" type="text" id="key" class="form-control">
+        </div>
+        <br>
+        <div class="input-group">
+          <span class="input-group-addon">Bing Cliend Secret</span>
+          <input ng-model="opctrl.bingTranslatorApiKey.clientSecret" ng-blur="opctrl.save({'bingTranslatorApiKey': {clientSecret: opctrl.bingTranslatorApiKey.clientSecret, clientId: opctrl.bingTranslatorApiKey.clientId}}, 'Updated')" type="text" id="key" class="form-control">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/includes/advanced.html
+++ b/lib/views/includes/advanced.html
@@ -159,21 +159,33 @@
         <div class="input-group">
           <span class="input-group-addon">Google Key</span>
           <input ng-model="opctrl.googleTranslatorApiKey" ng-blur="opctrl.save({'googleTranslatorApiKey': opctrl.googleTranslatorApiKey}, 'Updated')" type="text" id="key" class="form-control">
+          <span class="input-group-btn">
+            <a class="btn btn-success" href="https://cloud.google.com/translate/v2/quickstart" target="_blank">Get Google Key</a>
+          </span>
         </div>
         <br>
         <div class="input-group">
           <span class="input-group-addon">Yandex Key</span>
           <input ng-model="opctrl.yandexTranslatorApiKey" ng-blur="opctrl.save({'yandexTranslatorApiKey': opctrl.yandexTranslatorApiKey}, 'Updated')" type="text" id="key" class="form-control">
+          <span class="input-group-btn">
+            <a class="btn btn-success" href="https://tech.yandex.com/keys/get/?service=trnsl" target="_blank">Get Yandex Key</a>
+          </span>
         </div>
         <br>
         <div class="input-group">
           <span class="input-group-addon">Bing Client ID</span>
           <input ng-model="opctrl.bingTranslatorApiKey.clientId" ng-blur="opctrl.save({'bingTranslatorApiKey': {clientSecret: opctrl.bingTranslatorApiKey.clientSecret, clientId: opctrl.bingTranslatorApiKey.clientId}}, 'Updated')" type="text" id="key" class="form-control">
+          <span class="input-group-btn">
+            <a class="btn btn-success" href="https://www.microsoft.com/en-us/translator/getstarted.aspx" target="_blank">Get Bing Key</a>
+          </span>
         </div>
         <br>
         <div class="input-group">
-          <span class="input-group-addon">Bing Cliend Secret</span>
+          <span class="input-group-addon">Bing Client Secret</span>
           <input ng-model="opctrl.bingTranslatorApiKey.clientSecret" ng-blur="opctrl.save({'bingTranslatorApiKey': {clientSecret: opctrl.bingTranslatorApiKey.clientSecret, clientId: opctrl.bingTranslatorApiKey.clientId}}, 'Updated')" type="text" id="key" class="form-control">
+          <span class="input-group-btn">
+            <a class="btn btn-success" href="https://www.microsoft.com/en-us/translator/getstarted.aspx" target="_blank">Get Bing Key</a>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I have added the keys panel in the **advanced tab** instead of the *translation tab* because there is already a field of keys there. It would cause confusion to the user.

![keys](https://cloud.githubusercontent.com/assets/9019878/16982323/d1c454f2-4e8c-11e6-91f0-87601caf6a01.png)

Please suggest changes if needed.