### PR TITLE
Fix and catch errors 

### DIFF
--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -176,7 +176,7 @@ export class ContentScript {
       return !!word && word.length >= 2 && // no words that are too short
         word !== '' && !/\d/.test(word) && // no empty words
         word.charAt(0) !== word.charAt(0).toUpperCase() && // no proper nouns
-        !blackListReg.test(word.toLowerCase()) && // no blacklisted words
+        !(blackListReg.test(word.toLowerCase()) && blackListReg === '()') && // no blacklisted words
         !punctuationReg.test(word.toLowerCase()); // no punctuation marks
     }));
     var targetLength = Math.floor((Object.keys(countedWordsList).length * translationProbability) / 100);

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -46,7 +46,7 @@ export class ContentScript {
         this.autoBlacklist = res.autoBlacklist;
         var blacklistWebsiteReg = new RegExp(res.blacklist);
 
-        if (blacklistWebsiteReg.test(document.URL)) {
+        if (blacklistWebsiteReg.test(document.URL) && res.blacklist !== '()') {
           console.log('[MTW] Blacklisted website');
         } else if (res.doNotTranslate === true) {
           console.log('[MTW] Do Not Translate selected.');

--- a/lib/scripts/services/bingTranslate.js
+++ b/lib/scripts/services/bingTranslate.js
@@ -44,9 +44,14 @@ export class BingTranslate {
             .then((res) => {
               let translations = this.filterTranslations(res),
                 tMap = this.mapTranslations(translations, words);
-              console.log(tMap);
               resolve(tMap);
+            })
+            .catch((e) => {
+              reject(e);
             });
+        })
+        .catch((e) => {
+          reject(e);
         });
     });
     return promise;

--- a/lib/scripts/services/yandexTranslate.js
+++ b/lib/scripts/services/yandexTranslate.js
@@ -32,9 +32,11 @@ export class YandexTranslate {
       http(this.url)
         .get()
         .then((data) => {
-          console.log('words', words);
           var tMap = this.mapTranslations(JSON.parse(data), words);
           resolve(tMap);
+        })
+        .catch((e) => {
+          reject(e);
         });
     });
     return promise;


### PR DESCRIPTION
1. Empty blacklist caused all websites to be blacklisted
2. Empty blacklist word list causes all words to be blacklisted
3. Some errors generated were not properly caught