### PR TITLE
Translate one word per sentence

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,6 +20,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "core-js": "npm:core-js@1.2.6",
     "jquery": "npm:jquery@2.2.3",
+    "lodash": "npm:lodash@4.14.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },

--- a/lib/scripts/controllers/options.js
+++ b/lib/scripts/controllers/options.js
@@ -115,6 +115,7 @@ export class OptionCtrl {
       this.wordToggles = data.wordToggles;
       this.autoBlacklist = data.autoBlacklist;
       this.translatedWordsForQuiz = JSON.parse(data.translatedWordsForQuiz);
+      this.oneWordTranslation = data.oneWordTranslation;
       //randomly selected 10 words for the quiz
       this.randomTranslatedWordsForQuiz = this.randomlySelectTenWords(this.translatedWordsForQuiz);
       this.translatedWordsExist = Object.keys(this.randomTranslatedWordsForQuiz).length === 0 ? false : true;
@@ -291,6 +292,7 @@ export class OptionCtrl {
           translator,
           0
         ]);
+        this.translatorService = translator;
         this.$timeout(() => {
           this.$scope.$apply();
         });
@@ -316,6 +318,9 @@ export class OptionCtrl {
       }
     }
     if (index === parseInt(activatedPattern)) {
+      if (this.oneWordTranslation) {
+        this.toggleOneWordTranslation();
+      }
       this.deleteActivationData();
     }
     this.patterns.splice(index, 1);
@@ -328,6 +333,7 @@ export class OptionCtrl {
   }
 
   deleteActivationData() {
+    this.translatorService = '';
     // using chrome storage because we don't want any message to be displayed
     chrome.storage.local.set({
       translatorService: '',
@@ -413,6 +419,7 @@ export class OptionCtrl {
     this.deactivatePatterns();
     this.doNotTranslate = true;
     this.userDefinedOnly = false;
+    this.oneWordTranslation = false;
     this.save({
       translatorService: '',
       translationProbability: '',
@@ -420,7 +427,8 @@ export class OptionCtrl {
       targetLanguage: '',
       savedPatterns: JSON.stringify(this.patterns),
       doNotTranslate: true,
-      userDefinedOnly: false
+      userDefinedOnly: false,
+      oneWordTranslation: false
     }, 'Turned off Translations');
     this.$timeout(() => {
       this.$scope.$apply();
@@ -431,6 +439,7 @@ export class OptionCtrl {
     this.deactivatePatterns();
     this.userDefinedOnly = true;
     this.doNotTranslate = false;
+    this.oneWordTranslation = false;
     this.save({
       translatorService: '',
       translationProbability: '',
@@ -438,11 +447,30 @@ export class OptionCtrl {
       targetLanguage: '',
       savedPatterns: JSON.stringify(this.patterns),
       doNotTranslate: false,
-      userDefinedOnly: true
+      userDefinedOnly: true,
+      oneWordTranslation: false
     }, 'User Defined Transltions only');
     this.$timeout(() => {
       this.$scope.$apply();
     });
+  }
+
+  toggleOneWordTranslation() {
+    if (this.translatorService === '') {
+      this.status('Please select a Pattern', 1000, 100, 'danger');
+    } else {
+      this.userDefinedOnly = false;
+      this.doNotTranslate = false;
+      this.oneWordTranslation = !this.oneWordTranslation;
+      this.save({
+        doNotTranslate: false,
+        userDefinedOnly: false,
+        oneWordTranslation: this.oneWordTranslation
+      }, 'Toggle one word per sentence');
+      this.$timeout(() => {
+        this.$scope.$apply();
+      });
+    }
   }
 
   setKeyAlert() {

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -47,6 +47,7 @@ export class ContentScript {
         this.stats = res.stats;
         this.wordToggles = res.wordToggles;
         this.autoBlacklist = res.autoBlacklist;
+        this.oneWordTranslation = res.oneWordTranslation;
         var blacklistWebsiteReg = new RegExp(res.blacklist);
 
         if (blacklistWebsiteReg.test(document.URL) && res.blacklist !== '()') {
@@ -279,9 +280,14 @@ export class ContentScript {
     console.log(filteredTMap);
     if (Object.keys(filteredTMap).length !== 0) {
       var paragraphs = document.getElementsByTagName('p');
-      for (var i = 0; i < paragraphs.length; i++) {
-        this.oneWordTranslation(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
-        // this.deepHTMLReplacement(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
+      if (this.oneWordTranslation) {
+        for (var i = 0; i < paragraphs.length; i++) {
+          this.translateOneWord(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
+        }
+      } else {
+        for (var i = 0; i < paragraphs.length; i++) {
+          this.deepHTMLReplacement(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
+        }
       }
     }
 
@@ -294,8 +300,13 @@ export class ContentScript {
     }
   }
 
-
-  oneWordTranslation(paragraph, filteredTMap, iMap) {
+  /**
+   * Translate one word in each sentence for a  paragraph.
+   * @param {Object} paragraph - Paragraph nodeType
+   * @param {Object} filteredTMap - filtered translation map
+   * @param {Object} iMap - HTML element for each translated word
+   */
+  translateOneWord(paragraph, filteredTMap, iMap) {
     for (let i in paragraph.childNodes) {
       if (paragraph.childNodes[i].nodeType === 3) {
         if(!/^\s*$/.test(paragraph.childNodes[i].textContent)){

--- a/lib/scripts/mtw.js
+++ b/lib/scripts/mtw.js
@@ -2,6 +2,7 @@ import { YandexTranslate } from './services/yandexTranslate';
 import { BingTranslate } from './services/bingTranslate';
 import { GoogleTranslate } from './services/googleTranslate';
 import { getCurrentMonth,getCurrentDay } from './utils/dateAndTimeHelpers';
+import _ from 'lodash';
 
 
 /** Class for content scriptcontroller */
@@ -275,10 +276,12 @@ export class ContentScript {
       }
     });
 
+    console.log(filteredTMap);
     if (Object.keys(filteredTMap).length !== 0) {
       var paragraphs = document.getElementsByTagName('p');
       for (var i = 0; i < paragraphs.length; i++) {
-        this.deepHTMLReplacement(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
+        this.oneWordTranslation(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
+        // this.deepHTMLReplacement(paragraphs[i], filteredTMap, this.invertMap(filteredTMap));
       }
     }
 
@@ -288,6 +291,31 @@ export class ContentScript {
       translatedWords[i].addEventListener('click', () => {
         this.toggleElement(event, this.wordToggles, this.autoBlacklist);
       }, false);
+    }
+  }
+
+
+  oneWordTranslation(paragraph, filteredTMap, iMap) {
+    for (let i in paragraph.childNodes) {
+      if (paragraph.childNodes[i].nodeType === 3) {
+        if(!/^\s*$/.test(paragraph.childNodes[i].textContent)){
+          let sentences = paragraph.childNodes[i].textContent.split('.');
+          for (let j in sentences) {
+            let words = sentences[j].split(' ');
+            words = _.shuffle(words);
+            for (let k in words) {
+              if (filteredTMap[words[k]]) {
+                let x = sentences[j].replace(words[k], iMap[filteredTMap[words[k]]]);
+                sentences[j] = x;
+                break;
+              }
+            }
+          }
+          var newNode = document.createElement('span');
+          newNode.innerHTML = sentences.join('.');
+          paragraph.replaceChild(newNode, paragraph.childNodes[i]);
+        }
+      }
     }
   }
 

--- a/lib/scripts/utils/defaultStorage.js
+++ b/lib/scripts/utils/defaultStorage.js
@@ -31,4 +31,5 @@ export var localData = {
   wordToggles: 20,
   autoBlacklist: true,
   translatedWordsForQuiz: '{}',
+  oneWordTranslation: false
 };

--- a/lib/views/includes/translation.html
+++ b/lib/views/includes/translation.html
@@ -8,6 +8,9 @@
     <button type="button" ng-click="opctrl.toggleDoNotTranslate()" ng-class="{'active': opctrl.doNotTranslate}" class="btn btn-danger pull-right btn-xs" style="margin-right: 5px">
       <span class="glyphicon glyphicon-ok-sign" ng-show="opctrl.doNotTranslate"></span> Do Not Translate
     </button>
+    <button type="button" ng-click="opctrl.toggleOneWordTranslation()" ng-class="{'active': opctrl.oneWordTranslation}" class="btn btn-warning pull-right btn-xs" style="margin-right: 5px">
+      <span class="glyphicon glyphicon-ok-sign" ng-show="opctrl.oneWordTranslation"></span> One Word Per Sentence
+    </button>
   </div>
   <div ng-show="opctrl.patterns.length === 0" class="text-center">
     <h5 class="text-muted"><span class="glyphicon glyphicon-exclamation-sign"></span> Please insert the keys for the translation services that you would like to use and then create a new translation pattern below.</h5>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dependencies": {
       "angular": "github:angular/bower-angular@^1.5.5",
       "bootstrap": "github:twbs/bootstrap@^3.3.6",
-      "jquery": "npm:jquery@^2.2.3"
+      "jquery": "npm:jquery@^2.2.3",
+      "lodash": "npm:lodash@^4.14.0"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.8.24",


### PR DESCRIPTION
This PR adds functionality to translate one word in each sentence.

![onewordps](https://cloud.githubusercontent.com/assets/9019878/17258706/c8903af8-55e5-11e6-9487-2cebc52f961b.png)

It is significantly faster than the `replaceAll` function. Users can create a pattern and toggle the button if they want one word to be translated in each sentence. Clicking on the button again turns it off.